### PR TITLE
FI-574: Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: java
 
-script:
-  - ./gradlew build
+jobs:
+  include:
+    - script:
+        - ./gradlew build
 
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+      before_cache:
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+      cache:
+        directories:
+          - $HOME/.gradle/caches/
+          - $HOME/.gradle/wrapper/
+
+    - services:
+        - docker
+      script:
+        - docker build -t hl7_validator .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+
+script:
+  - ./gradlew build
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: java
 
 jobs:
   include:
-    - script:
+    - name: "Build and Test"
+      script:
         - ./gradlew build
 
       before_cache:
@@ -14,7 +15,8 @@ jobs:
           - $HOME/.gradle/caches/
           - $HOME/.gradle/wrapper/
 
-    - services:
+    - name: "Docker Build"
+      services:
         - docker
       script:
         - docker build -t hl7_validator .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HL7 FHIR Validation Service
 
+[![Build Status](https://travis-ci.com/inferno-community/fhir-validator-wrapper.svg?branch=master)](https://travis-ci.com/inferno-community/fhir-validator-wrapper)
+
 The `fhir-validator-wrapper` provides a persistent service for executing the 
 [FHIR® Validator](https://wiki.hl7.org/Using_the_FHIR_Validator). It is intended to provide validation capabilities
 to other applications that integrate it.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
     // the ig-publisher uses this one too
     // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "4.1.22-SNAPSHOT")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "4.1.41-SNAPSHOT")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")


### PR DESCRIPTION
Adds Travis CI configuration and status badge.

Has two jobs parallel jobs:
1.  Building, testing and style checking the application 
2. Running the docker build

Also bumps the FHIR validator dependency version.