### PR TITLE
Add SLF4J for Spark logging, and enable request logging in Spark

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     // GSON for our JSON needs
     implementation("com.google.code.gson", "gson", "2.8.6")
 
+    implementation("org.slf4j", "slf4j-log4j12", "1.7.30")
+
     // Web Server
     implementation("com.sparkjava", "spark-core", "2.9.1")
 

--- a/src/main/java/org/mitre/inferno/App.java
+++ b/src/main/java/org/mitre/inferno/App.java
@@ -1,6 +1,9 @@
 package org.mitre.inferno;
 
 import org.mitre.inferno.rest.ValidatorEndpoint;
+import org.mitre.inferno.utils.SparkUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class App {
 
@@ -10,12 +13,13 @@ public class App {
    * @param args the application initialization arguments
    */
   public static void main(String[] args) {
+    Logger logger = LoggerFactory.getLogger(App.class);
     if (args.length > 0) {
       if (args[0].equals("prepare")) {
-        System.out.println("Initializing Validator App...");
+        logger.info("Initializing Validator App...");
         initializeValidator();
       } else {
-        System.out.println("Argument " + args[0] + " is unknown");
+        logger.warn("Argument " + args[0] + " is unknown");
         startApp();
       }
     } else {
@@ -35,7 +39,9 @@ public class App {
    * Starts the app.
    */
   private static void startApp() {
-    System.out.println("Starting Server...");
+    Logger logger = LoggerFactory.getLogger(App.class);
+    logger.info("Starting Server...");
+    SparkUtils.createServerWithRequestLog(logger);
     ValidatorEndpoint.getInstance();
   }
 }

--- a/src/main/java/org/mitre/inferno/utils/EmbeddedJettyFactoryConstructor.java
+++ b/src/main/java/org/mitre/inferno/utils/EmbeddedJettyFactoryConstructor.java
@@ -1,0 +1,19 @@
+package org.mitre.inferno.utils;
+
+import org.eclipse.jetty.server.CustomRequestLog;
+import spark.embeddedserver.jetty.EmbeddedJettyFactory;
+
+public class EmbeddedJettyFactoryConstructor {
+  CustomRequestLog requestLog;
+
+  public EmbeddedJettyFactoryConstructor(CustomRequestLog requestLog) {
+    this.requestLog = requestLog;
+  }
+
+  EmbeddedJettyFactory create() {
+    EmbeddedJettyServerFactory embeddedJettyServerFactory = new EmbeddedJettyServerFactory(this);
+
+    return new EmbeddedJettyFactory(embeddedJettyServerFactory);
+  }
+
+}

--- a/src/main/java/org/mitre/inferno/utils/EmbeddedJettyServerFactory.java
+++ b/src/main/java/org/mitre/inferno/utils/EmbeddedJettyServerFactory.java
@@ -1,0 +1,35 @@
+package org.mitre.inferno.utils;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import spark.embeddedserver.jetty.JettyServerFactory;
+
+class EmbeddedJettyServerFactory implements JettyServerFactory {
+  private EmbeddedJettyFactoryConstructor embeddedJettyFactoryConstructor;
+  
+  EmbeddedJettyServerFactory(EmbeddedJettyFactoryConstructor embeddedJettyFactoryConstructor) {
+    this.embeddedJettyFactoryConstructor = embeddedJettyFactoryConstructor;
+  }
+  
+  @Override
+  public Server create(int maxThreads, int minThreads, int threadTimeoutMillis) {
+    Server server;
+    if (maxThreads > 0) {
+      int max = maxThreads > 0 ? maxThreads : 200;
+      int min = minThreads > 0 ? minThreads : 8;
+      int idleTimeout = threadTimeoutMillis > 0 ? threadTimeoutMillis : 60;
+      server = new Server(new QueuedThreadPool(max, min, idleTimeout));
+    } else {
+      server = new Server();
+    }
+    
+    server.setRequestLog(embeddedJettyFactoryConstructor.requestLog);
+    return server;
+  }
+  
+  @Override
+  public Server create(ThreadPool threadPool) {
+    return new Server(threadPool);
+  }
+}

--- a/src/main/java/org/mitre/inferno/utils/RequestLogFactory.java
+++ b/src/main/java/org/mitre/inferno/utils/RequestLogFactory.java
@@ -1,10 +1,10 @@
 package org.mitre.inferno.utils;
 
-import org.eclipse.jetty.server.Slf4jRequestLogWriter;
-import org.eclipse.jetty.server.CustomRequestLog;
-import org.slf4j.Logger;
-
 import java.io.IOException;
+
+import org.eclipse.jetty.server.CustomRequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
+import org.slf4j.Logger;
 
 public class RequestLogFactory {
   

--- a/src/main/java/org/mitre/inferno/utils/RequestLogFactory.java
+++ b/src/main/java/org/mitre/inferno/utils/RequestLogFactory.java
@@ -1,0 +1,36 @@
+package org.mitre.inferno.utils;
+
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
+import org.eclipse.jetty.server.CustomRequestLog;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+public class RequestLogFactory {
+  
+  private Logger logger;
+  private CustomRequestLog crl;
+  
+  public RequestLogFactory(Logger logger) {
+    this.logger = logger;
+    this.crl = new CustomRequestLog(create(), CustomRequestLog.EXTENDED_NCSA_FORMAT);
+  }
+  
+  Slf4jRequestLogWriter create() {
+    return new Slf4jRequestLogWriter() {
+      @Override
+      protected boolean isEnabled() {
+        return true;
+      }
+      
+      @Override
+      public void write(String s) throws IOException {
+        logger.info(s);
+      }
+    };
+  }
+  
+  public CustomRequestLog getLog() {
+    return this.crl;
+  }
+}

--- a/src/main/java/org/mitre/inferno/utils/SparkUtils.java
+++ b/src/main/java/org/mitre/inferno/utils/SparkUtils.java
@@ -1,0 +1,18 @@
+package org.mitre.inferno.utils;
+
+import org.slf4j.Logger;
+import org.eclipse.jetty.server.CustomRequestLog;
+import spark.embeddedserver.EmbeddedServers;
+import spark.embeddedserver.jetty.EmbeddedJettyFactory;
+
+public class SparkUtils {
+  public static void createServerWithRequestLog(Logger logger) {
+    EmbeddedJettyFactory factory = createEmbeddedJettyFactoryWithRequestLog(logger);
+    EmbeddedServers.add(EmbeddedServers.Identifiers.JETTY, factory);
+  }
+
+  private static EmbeddedJettyFactory createEmbeddedJettyFactoryWithRequestLog(Logger logger) {
+    CustomRequestLog requestLog = new RequestLogFactory(logger).getLog();
+    return new EmbeddedJettyFactoryConstructor(requestLog).create();
+  }
+}

--- a/src/main/java/org/mitre/inferno/utils/SparkUtils.java
+++ b/src/main/java/org/mitre/inferno/utils/SparkUtils.java
@@ -1,7 +1,7 @@
 package org.mitre.inferno.utils;
 
-import org.slf4j.Logger;
 import org.eclipse.jetty.server.CustomRequestLog;
+import org.slf4j.Logger;
 import spark.embeddedserver.EmbeddedServers;
 import spark.embeddedserver.jetty.EmbeddedJettyFactory;
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Turns out the Java Spark framework needs SLF4J to be added to Gradle to support logging. This PR does that, and also adds a couple of factories to be able to generate a Jetty server instance with request logging through SLF4J baked in.