### PR TITLE
Allow Any Extensions

### DIFF
--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -71,6 +71,7 @@ public class Validator {
     hl7Validator.loadIg(igFile, true);
     hl7Validator.connectToTSServer(txServer, txLog, FhirPublication.fromCode(fhirVersion));
     hl7Validator.setNative(false);
+    hl7Validator.setAnyExtensionsAllowed(true);
     hl7Validator.prepare();
   }
 


### PR DESCRIPTION
This allows the validator to accept resources containing any extensions.

Previously unknown extensions would cause an error to be thrown with "The extension http://whatever.com/extension#resource.element".

This update causes these errors to be turned into warnings with the message: "Unknown extension http://whatever.com/extension#resource.element"

Extensions that are known will still be validated normally.