### PR TITLE
Add a function to get the Terminology server URL from an environment variable, with a default

### DIFF
--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -63,7 +63,7 @@ public class Validator {
     final String fhirSpecVersion = "4.0";
     final String definitions = VersionUtilities.packageForVersion(fhirSpecVersion)
         + "#" + VersionUtilities.getCurrentVersion(fhirSpecVersion);
-    final String txServer = "http://tx.fhir.org";
+    final String txServer = getTxServerURL();
     final String txLog = null;
     final String fhirVersion = "4.0.1";
 
@@ -136,5 +136,13 @@ public class Validator {
     ClassLoader classLoader = getClass().getClassLoader();
     URL file = classLoader.getResource(src);
     return IOUtils.toByteArray(file);
+  }
+
+  private String getTxServerURL() {
+    if (System.getenv("TX_SERVER_URL") != null) {
+      return System.getenv("TX_SERVER_URL");
+    } else {
+      return "http://tx.fhir.org";
+    }
   }
 }


### PR DESCRIPTION
add a `getTxServerURL` function to `Validator.java`. This function pulls the terminology server URL from the `TX_SERVER_URL`. If that environment variable isn't present, we default to `http://tx.fhir.org`.

Design note: I did consider passing `txServer` into the `Validator` initializer, but then I would have had to add the environment variable grab function to at least two places in the app. Keeping the function in the `Validator` class lets me DRY that up.