### PR TITLE
FI-659 Environment Variable to Disable Terminology Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Run
 ```shell script
 docker run -p 4567:4567 hl7_validator
 ```
+
+Run with a different terminology server:
+```shell script
+docker run -p 4567:4567 --env TX_SERVER_URL=http://mytx.org/r4 hl7_validator
+```
+
+Run without terminology validation:
+```shell script
+docker run -p 4567:4567 --env DISABLE_TX=true hl7_validator
+```
 ## Contact Us
 The Inferno development team can be reached by email at inferno@groups.mitre.org.  Inferno also has a dedicated [HL7 FHIR chat channel](https://chat.fhir.org/#narrow/stream/153-inferno).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
     // the ig-publisher uses this one too
     // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "4.1.41-SNAPSHOT")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "4.3.1-SNAPSHOT")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -63,7 +63,7 @@ public class Validator {
     final String fhirSpecVersion = "4.0";
     final String definitions = VersionUtilities.packageForVersion(fhirSpecVersion)
         + "#" + VersionUtilities.getCurrentVersion(fhirSpecVersion);
-    final String txServer = getTxServerURL();
+    final String txServer = getTxServerUrl();
     final String txLog = null;
     final String fhirVersion = "4.0.1";
 
@@ -138,11 +138,19 @@ public class Validator {
     return IOUtils.toByteArray(file);
   }
 
-  private String getTxServerURL() {
+  private String getTxServerUrl() {
+    if (disableTxValidation()) {
+      return null;
+    }
+
     if (System.getenv("TX_SERVER_URL") != null) {
       return System.getenv("TX_SERVER_URL");
     } else {
       return "http://tx.fhir.org";
     }
+  }
+
+  private boolean disableTxValidation() {
+    return System.getenv("DISABLE_TX") != null;
   }
 }


### PR DESCRIPTION
Adds an environment variable `DISABLE_TX` which can be used to turn off external terminology validation.  Also renames a method to fix a checkstyle issue and updates the validator to the latest snapshot.

Note that some `invalid-code` results that do not use an external terminology server may occur.