### PR TITLE
Updates to a) support XML format validation, and 2) Allow for the setting of the port with a VALIDATOR_PORT environment variable

### DIFF
--- a/src/main/java/org/mitre/inferno/App.java
+++ b/src/main/java/org/mitre/inferno/App.java
@@ -41,6 +41,14 @@ public class App {
     Logger logger = LoggerFactory.getLogger(App.class);
     logger.info("Starting Server...");
     SparkUtils.createServerWithRequestLog(logger);
-    ValidatorEndpoint.getInstance();
+    ValidatorEndpoint.getInstance(getPortNumber());
+  }
+
+  private static int getPortNumber() {
+    if (System.getenv("VALIDATOR_PORT") != null) {
+      return Integer.parseInt(System.getenv("VALIDATOR_PORT"));
+    } else {
+      return 4567;
+    }
   }
 }

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -93,7 +93,8 @@ public class Validator {
   }
 
   public OperationOutcome validate(byte[] resource, List<String> profile) throws Exception {
-    return this.hl7Validator.validate(null, resource, Manager.FhirFormat.JSON, profile);
+    Manager.FhirFormat fmt = FormatUtilities.determineFormat(resource);
+    return this.hl7Validator.validate(null, resource, fmt, profile);
   }
 
   /**

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -2,6 +2,7 @@ package org.mitre.inferno.rest;
 
 import static spark.Spark.get;
 import static spark.Spark.post;
+import static spark.Spark.port;
 
 import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
@@ -22,7 +23,8 @@ public class ValidatorEndpoint {
   private static ValidatorEndpoint validatorEndpoint = null;
   private static Validator _validator = null;
 
-  private ValidatorEndpoint() {
+  private ValidatorEndpoint(int portNum) {
+    port(portNum);
     createRoutes();
   }
 
@@ -31,9 +33,9 @@ public class ValidatorEndpoint {
    *
    * @return
    */
-  public static ValidatorEndpoint getInstance() {
+  public static ValidatorEndpoint getInstance(int portNum) {
     if (validatorEndpoint == null) {
-      validatorEndpoint = new ValidatorEndpoint();
+      validatorEndpoint = new ValidatorEndpoint(portNum);
     }
     return validatorEndpoint;
   }


### PR DESCRIPTION
This PR:
* Uses the FHIR utils to "figure out" which format object it's been passed. This allows us to validate both JSON and XML
* Adds a VALIDATOR_PORT environment variable support for passing in a port to run on other than 4567
