### PR TITLE
Support sending in a comma-separated list of profiles using the 'profile' param

### DIFF
--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -92,9 +92,9 @@ public class Validator {
         .collect(Collectors.toList());
   }
 
-  public OperationOutcome validate(byte[] resource, List<String> profile) throws Exception {
+  public OperationOutcome validate(byte[] resource, List<String> profiles) throws Exception {
     Manager.FhirFormat fmt = FormatUtilities.determineFormat(resource);
-    return this.hl7Validator.validate(null, resource, fmt, profile);
+    return this.hl7Validator.validate(null, resource, fmt, profiles);
   }
 
   /**

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -139,8 +140,7 @@ public class ValidatorEndpoint {
    * @throws Exception if the resource cannot be loaded or validated
    */
   private String validateResource(byte[] resource, String profile) throws Exception {
-    ArrayList<String> patientProfiles = new ArrayList<>();
-    patientProfiles.add(profile);
+    ArrayList<String> patientProfiles = new ArrayList<String>(Arrays.asList(profile.split(",")));
     OperationOutcome oo = validator().validate(resource, patientProfiles);
     return resourceToJson(oo);
   }

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -80,6 +80,17 @@ public class ValidatorTest {
   }
 
   @Test
+  void validateMultipleProfiles() {
+    try {
+      byte[] example = loadFile("us_core_patient_example.json");
+      validator.validate(example, Arrays.asList("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient", "http://hl7.org/fhir/StructureDefinition/Patient"));
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
+    }
+  }
+
+  @Test
   void getKnownIGs() {
     List<String> knownIGs = validator.getKnownIGs();
     assertTrue(knownIGs.contains("http://hl7.org/fhir/us/core"));


### PR DESCRIPTION
This PR adds support to the fhir-validator-wrapper for validating multiple profiles for a single resource.

The profiles should be passed in as a comma-separated list, e.g. `/validate?profile=<profile1_url>,<profile2_url>,<etc.>`

Single-profile validation is still supported; just pass in the singular profile without any commas.﻿
