### PR TITLE
Load IG packages from packages.fhir.org

### DIFF
--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -101,12 +101,9 @@ public class Validator {
   }
 
   private List<String> getProfileUrls(String id) throws IOException {
-    String version = null;
-    if (id.contains("#")) {
-      int index = id.indexOf("#");
-      version = id.substring(index + 1);
-      id = id.substring(0, index);
-    }
+    String[] fragments = id.split("#");
+    id = fragments[0];
+    String version = fragments.length > 1 ? fragments[1] : null;
     NpmPackage npm = packageManager.loadPackage(id, version);
     InputStream in = npm.load(".index.json");
     JsonObject index = (JsonObject) JsonParser.parseString(TextFile.streamToString(in));

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -101,7 +101,7 @@ public class Validator {
   }
 
   private List<String> getProfileUrls(String id) throws IOException {
-    String version = "current";
+    String version = null;
     if (id.contains("#")) {
       int index = id.indexOf("#");
       version = id.substring(index + 1);

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -101,7 +101,13 @@ public class Validator {
   }
 
   private List<String> getProfileUrls(String id) throws IOException {
-    NpmPackage npm = packageManager.loadPackage(id, "current");
+    String version = "current";
+    if (id.contains("#")) {
+      int index = id.indexOf("#");
+      version = id.substring(index + 1);
+      id = id.substring(0, index);
+    }
+    NpmPackage npm = packageManager.loadPackage(id, version);
     InputStream in = npm.load(".index.json");
     JsonObject index = (JsonObject) JsonParser.parseString(TextFile.streamToString(in));
 

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -101,7 +101,7 @@ public class Validator {
   }
 
   private List<String> getProfileUrls(String id) throws IOException {
-    NpmPackage npm = packageManager.loadPackage(id, null);
+    NpmPackage npm = packageManager.loadPackage(id, "current");
     InputStream in = npm.load(".index.json");
     JsonObject index = (JsonObject) JsonParser.parseString(TextFile.streamToString(in));
 

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -99,9 +99,7 @@ public class ValidatorEndpoint {
         (req, res) -> {
           res.type("application/json");
           try {
-            loadIg(req.params("id"));
-            res.status(200);
-            return "";
+            return loadIg(req.params("id"));
           } catch (Exception e) {
             res.status(500);
             e.printStackTrace();
@@ -127,11 +125,11 @@ public class ValidatorEndpoint {
    * Handles loading FHIR IGs into the validator or fetching them from the packages.fhir.org
    * repository if they don't exist.
    *
-   * @param src the FHIR IG to be loaded
+   * @param id the package ID of the FHIR IG to be loaded
    * @throws Exception if the IG could not be loaded
    */
-  private void loadIg(String src) throws Exception {
-    validator.loadIg(src);
+  private String loadIg(String id) throws Exception {
+    return new Gson().toJson(validator.loadIg(id));
   }
 
   /**

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -5,6 +5,7 @@ import static spark.Spark.get;
 import static spark.Spark.options;
 import static spark.Spark.port;
 import static spark.Spark.post;
+import static spark.Spark.put;
 
 import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
@@ -53,7 +54,7 @@ public class ValidatorEndpoint {
     // This adds permissive CORS headers to all requests
     before((req, res) -> {
       res.header("Access-Control-Allow-Origin", "*");
-      res.header("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+      res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
       res.header("Access-Control-Allow-Headers", "Access-Control-Allow-Origin, Content-Type");
     });
 
@@ -94,11 +95,11 @@ public class ValidatorEndpoint {
           return new Gson().toJson(validator.getProfilesByIg());
         });
 
-    post("/ig",
+    put("/igs/:id",
         (req, res) -> {
           res.type("application/json");
           try {
-            loadIg(req.queryParams("src"));
+            loadIg(req.params("id"));
             res.status(200);
             return "";
           } catch (Exception e) {

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -132,7 +132,7 @@ public class ValidatorEndpoint {
    *
    * @return a list of IG URLs
    */
-  private String getIGs() {
+  private String getIGs() throws IOException {
     return new Gson().toJson(validator.getKnownIGs());
   }
 

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -3,8 +3,8 @@ package org.mitre.inferno.rest;
 import static spark.Spark.before;
 import static spark.Spark.get;
 import static spark.Spark.options;
-import static spark.Spark.post;
 import static spark.Spark.port;
+import static spark.Spark.post;
 
 import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
@@ -57,7 +57,8 @@ public class ValidatorEndpoint {
       res.header("Access-Control-Allow-Headers", "Access-Control-Allow-Origin, Content-Type");
     });
 
-    // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests, with a 200 OK response with no content and the CORS headers above
+    // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests,
+    // with a 200 OK response with no content and the CORS headers above
     options("*",
         (req, res) -> {
           return "";
@@ -87,6 +88,26 @@ public class ValidatorEndpoint {
           return getIGs();
         });
 
+    get("/profiles-by-ig",
+        (req, res) -> {
+          res.type("application/json");
+          return new Gson().toJson(validator.getProfilesByIg());
+        });
+
+    post("/ig",
+        (req, res) -> {
+          res.type("application/json");
+          try {
+            loadIg(req.queryParams("src"));
+            res.status(200);
+            return "";
+          } catch (Exception e) {
+            res.status(500);
+            e.printStackTrace();
+            return "";
+          }
+        });
+
     post("/profile",
         (req, res) -> {
           byte[] profile = req.bodyAsBytes();
@@ -99,6 +120,17 @@ public class ValidatorEndpoint {
             return "";
           }
         });
+  }
+
+  /**
+   * Handles loading FHIR IGs into the validator or fetching them from the packages.fhir.org
+   * repository if they don't exist.
+   *
+   * @param src the FHIR IG to be loaded
+   * @throws Exception if the IG could not be loaded
+   */
+  private void loadIg(String src) throws Exception {
+    validator.loadIg(src);
   }
 
   /**

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -1,5 +1,6 @@
 package org.mitre.inferno;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -106,29 +107,77 @@ public class ValidatorTest {
   @Test
   void loadIg() throws Exception {
     List<String> profilesToLoad = Arrays.asList(
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-condition-parent",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genetic-variant",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genomics-report",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-radiation-procedure",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure",
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-parent"
+    );
+    assertTrue(profilesToLoad.stream().noneMatch(this::isProfileLoaded));
+
+    // Because the version isn't given, this should load the "current" version of hl7.fhir.us.mcode
+    List<String> profileUrls = validator.loadIg("hl7.fhir.us.mcode");
+    assertTrue(profileUrls.containsAll(profilesToLoad));
+    assertTrue(profilesToLoad.stream().allMatch(this::isProfileLoaded));
+  }
+
+  @Test
+  void loadIgWithVersions() throws Exception {
+    // A subset of the 45 profiles in hl7.fhir.us.qicore#3.3.0
+    List<String> oldProfilesToLoad = Arrays.asList(
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense",
-        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotdispensed",
-        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement",
-        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered",
-        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDone",
-        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-military-service",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-nutritionorder",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation",
-        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"
     );
-    assertTrue(profilesToLoad.stream().noneMatch(this::isProfileLoaded));
-    List<String> profileUrls = validator.loadIg("hl7.fhir.us.qicore");
-    assertTrue(profileUrls.containsAll(profilesToLoad));
-    assertTrue(profilesToLoad.stream().allMatch(this::isProfileLoaded));
+    assertTrue(oldProfilesToLoad.stream().noneMatch(this::isProfileLoaded));
+
+    List<String> profileUrls = validator.loadIg("hl7.fhir.us.qicore#3.3.0");
+    assertEquals(45, profileUrls.size());
+
+    // All old profiles to load have been loaded and are returned in the resulting list
+    assertTrue(profileUrls.containsAll(oldProfilesToLoad));
+    assertTrue(oldProfilesToLoad.stream().allMatch(this::isProfileLoaded));
+
+    // All of the profiles that are in hl7.fhir.us.qicore#4.9.0, but not hl7.fhir.us.qicore#3.3.0
+    List<String> newProfilesToLoad = Arrays.asList(
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicenotrequested",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-isElective",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotdispensed",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"
+    );
+
+    // There are 15 added profiles and 2 removed profiles going from version 3.3.0 to 4.9.0
+    profileUrls = validator.loadIg("hl7.fhir.us.qicore#4.9.0");
+    assertEquals(58, profileUrls.size());
+
+    // All new profiles to load have been loaded and are returned in the resulting list
+    assertTrue(profileUrls.containsAll(newProfilesToLoad));
+    assertTrue(newProfilesToLoad.stream().allMatch(this::isProfileLoaded));
   }
 
   boolean isProfileLoaded(String profile) {

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -105,10 +105,30 @@ public class ValidatorTest {
 
   @Test
   void loadIg() throws Exception {
-    assertFalse(isProfileLoaded("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+    List<String> profilesToLoad = Arrays.asList(
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotdispensed",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-nutritionorder",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole",
+        "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"
+    );
+    assertTrue(profilesToLoad.stream().noneMatch(this::isProfileLoaded));
     List<String> profileUrls = validator.loadIg("hl7.fhir.us.qicore");
-    assertTrue(profileUrls.contains("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
-    assertTrue(isProfileLoaded("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+    assertTrue(profileUrls.containsAll(profilesToLoad));
+    assertTrue(profilesToLoad.stream().allMatch(this::isProfileLoaded));
   }
 
   boolean isProfileLoaded(String profile) {

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -170,6 +170,7 @@ public class ValidatorTest {
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded",
         "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"
     );
+    assertTrue(newProfilesToLoad.stream().noneMatch(this::isProfileLoaded));
 
     // There are 15 added profiles and 2 removed profiles going from version 3.3.0 to 4.9.0
     profileUrls = validator.loadIg("hl7.fhir.us.qicore#4.9.0");

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.formats.FormatUtilities;
@@ -97,9 +97,9 @@ public class ValidatorTest {
   }
 
   @Test
-  void getKnownIGs() {
-    List<String> knownIGs = validator.getKnownIGs();
-    assertTrue(knownIGs.contains("hl7.fhir.r4.core#4.0.1"));
+  void getKnownIGs() throws IOException {
+    Set<String> knownIGs = validator.getKnownIGs().keySet();
+    assertTrue(knownIGs.contains("hl7.fhir.r4.core"));
   }
 
   boolean isProfileLoaded(String profile) {

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.hl7.fhir.r5.elementmodel.Manager;
@@ -100,6 +101,14 @@ public class ValidatorTest {
   void getKnownIGs() throws IOException {
     Set<String> knownIGs = validator.getKnownIGs().keySet();
     assertTrue(knownIGs.contains("hl7.fhir.r4.core"));
+  }
+
+  @Test
+  void loadIg() throws Exception {
+    assertFalse(isProfileLoaded("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+    List<String> profileUrls = validator.loadIg("hl7.fhir.us.qicore");
+    assertTrue(profileUrls.contains("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+    assertTrue(isProfileLoaded("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
   }
 
   boolean isProfileLoaded(String profile) {


### PR DESCRIPTION
This PR adds two new endpoints to the validator: `PUT /igs/:id`, which loads an IG from packages.fhir.org into the validator, and `GET /profiles-by-ig`, which retrieves a mapping from IG to a list of canonical urls for profiles of that IG.