### PR TITLE
Simplify Spark routes and standardize responses

### DIFF
--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.formats.FormatUtilities;
 import org.hl7.fhir.r5.model.FhirPublication;
@@ -93,11 +92,13 @@ public class Validator {
 
   /**
    * Load a profile into the validator.
+   *
    * @param profile the profile to be loaded
    */
-  public void loadProfile(Resource profile) {
-    SimpleWorkerContext context = hl7Validator.getContext();
-    context.cacheResource(profile);
+  public void loadProfile(byte[] profile) throws IOException {
+    Manager.FhirFormat fmt = FormatUtilities.determineFormat(profile);
+    Resource resource = FormatUtilities.makeParser(fmt).parse(profile);
+    hl7Validator.getContext().cacheResource(resource);
   }
 
   private List<String> getProfileUrls(String id) throws IOException {
@@ -162,9 +163,7 @@ public class Validator {
    * @throws IOException if the file fails to load
    */
   public void loadProfileFromFile(String src) throws IOException {
-    byte[] resource = loadResourceFromFile(src);
-    Manager.FhirFormat fmt = FormatUtilities.determineFormat(resource);
-    Resource profile = FormatUtilities.makeParser(fmt).parse(resource);
+    byte[] profile = loadResourceFromFile(src);
     loadProfile(profile);
   }
 

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -57,6 +57,11 @@ public class Validator {
     packageManager = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
   }
 
+  /**
+   * Lists the names of resources defined for this version of the validator.
+   *
+   * @return a sorted list of distinct resource names
+   */
   public List<String> getResources() {
     return hl7Validator.getContext().getResourceNames()
         .stream()
@@ -68,7 +73,7 @@ public class Validator {
   /**
    * Lists the StructureDefinitions loaded in the validator.
    *
-   * @return structures the list of structures
+   * @return a sorted list of distinct structure canonicals
    */
   public List<String> getStructures() {
     List<StructureDefinition> structures = hl7Validator.getContext().getStructures();
@@ -80,15 +85,23 @@ public class Validator {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Validates the given resource against the given list of profiles.
+   *
+   * @param resource a byte array representation of a FHIR resource
+   * @param profiles a list of profile URLs to validate against
+   * @return an OperationOutcome resource representing the result of the validation operation
+   * @throws Exception if there was an error validating the resource
+   */
   public OperationOutcome validate(byte[] resource, List<String> profiles) throws Exception {
     Manager.FhirFormat fmt = FormatUtilities.determineFormat(resource);
     return hl7Validator.validate(null, resource, fmt, profiles);
   }
 
   /**
-   * Provides a list of known IGs that can be retrieved and loaded.
+   * Provides a map of known IGs that can be retrieved and loaded.
    *
-   * @return the list of IGs.
+   * @return a map containing each known IG ID and its corresponding canonical URL.
    */
   public Map<String, String> getKnownIGs() throws IOException {
     Map<String, String> igs = new HashMap<>();

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -163,7 +163,7 @@ public class Validator {
     return igs
         .stream()
         .collect(Collectors.toMap(
-            ig -> ig.getPackageId() + (ig.hasVersion() ? "#" + ig.getVersion() : ""),
+            ImplementationGuide::getPackageId,
             ig -> {
               try {
                 return getProfileUrls(ig.getPackageId());

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -58,7 +58,11 @@ public class Validator {
   }
 
   public List<String> getResources() {
-    return hl7Validator.getContext().getResourceNames();
+    return hl7Validator.getContext().getResourceNames()
+        .stream()
+        .sorted()
+        .distinct()
+        .collect(Collectors.toList());
   }
 
   /**
@@ -71,6 +75,8 @@ public class Validator {
     return structures
         .stream()
         .map(StructureDefinition::getUrl)
+        .sorted()
+        .distinct()
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -8,13 +8,11 @@ import static spark.Spark.post;
 import static spark.Spark.put;
 
 import com.google.gson.Gson;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
 import org.hl7.fhir.r5.formats.FormatUtilities;
-import org.hl7.fhir.r5.formats.IParser;
 import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.Resource;
@@ -106,21 +104,8 @@ public class ValidatorEndpoint {
    * @throws Exception if the resource cannot be loaded or validated
    */
   private String validateResource(byte[] resource, String profile) throws Exception {
-    ArrayList<String> patientProfiles = new ArrayList<String>(Arrays.asList(profile.split(",")));
+    List<String> patientProfiles = Arrays.asList(profile.split(","));
     OperationOutcome oo = validator.validate(resource, patientProfiles);
-    return resourceToJson(oo);
-  }
-
-  /**
-   * Serializes a FHIR resource to its JSON representation.
-   * @param resource the resource to be serialized
-   * @return the serialized FHIR resource
-   * @throws IOException if the resource fails to be serialized
-   */
-  private String resourceToJson(Resource resource) throws IOException {
-    IParser parser = new JsonParser();
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    parser.compose(baos, resource);
-    return baos.toString();
+    return new JsonParser().composeString(oo);
   }
 }

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -70,17 +70,17 @@ public class ValidatorEndpoint {
 
     get("/profiles", (req, res) -> validator.getStructures(), TO_JSON);
 
-    get("/igs", (req, res) -> validator.getKnownIGs(), TO_JSON);
-
-    get("/profiles-by-ig", (req, res) -> validator.getProfilesByIg(), TO_JSON);
-
-    put("/igs/:id", (req, res) -> validator.loadIg(req.params("id")), TO_JSON);
-
-    post("/profile",
+    post("/profiles",
         (req, res) -> {
           loadProfile(req.bodyAsBytes());
           return "";
         });
+
+    get("/profiles-by-ig", (req, res) -> validator.getProfilesByIg(), TO_JSON);
+
+    get("/igs", (req, res) -> validator.getKnownIGs(), TO_JSON);
+
+    put("/igs/:id", (req, res) -> validator.loadIg(req.params("id")), TO_JSON);
   }
 
   /**

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -56,14 +56,12 @@ public class ValidatorEndpoint {
       res.header("Access-Control-Allow-Origin", "*");
       res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
       res.header("Access-Control-Allow-Headers", "Access-Control-Allow-Origin, Content-Type");
+      res.type("application/json");
     });
 
     // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests,
     // with a 200 OK response with no content and the CORS headers above
-    options("*",
-        (req, res) -> {
-          return "";
-        });
+    options("*", (req, res) -> "");
 
     post("/validate",
         (req, res) -> {
@@ -71,53 +69,20 @@ public class ValidatorEndpoint {
           return validateResource(req.bodyAsBytes(), req.queryParams("profile"));
         });
 
-    get("/resources",
-        (req, res) -> {
-          res.type("application/json");
-          return resourcesList();
-        });
+    get("/resources", (req, res) -> resourcesList());
 
-    get("/profiles",
-        (req, res) -> {
-          res.type("application/json");
-          return getProfiles();
-        });
+    get("/profiles", (req, res) -> getProfiles());
 
-    get("/igs",
-        (req, res) -> {
-          res.type("application/json");
-          return getIGs();
-        });
+    get("/igs", (req, res) -> getIGs());
 
-    get("/profiles-by-ig",
-        (req, res) -> {
-          res.type("application/json");
-          return new Gson().toJson(validator.getProfilesByIg());
-        });
+    get("/profiles-by-ig", (req, res) -> new Gson().toJson(validator.getProfilesByIg()));
 
-    put("/igs/:id",
-        (req, res) -> {
-          res.type("application/json");
-          try {
-            return loadIg(req.params("id"));
-          } catch (Exception e) {
-            res.status(500);
-            e.printStackTrace();
-            return "";
-          }
-        });
+    put("/igs/:id", (req, res) -> loadIg(req.params("id")));
 
     post("/profile",
         (req, res) -> {
-          byte[] profile = req.bodyAsBytes();
-          try {
-            loadProfile(profile);
-            res.status(200);
-            return "";
-          } catch (IOException e) {
-            res.status(500);
-            return "";
-          }
+          loadProfile(req.bodyAsBytes());
+          return "";
         });
   }
 

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -8,14 +8,10 @@ import static spark.Spark.post;
 import static spark.Spark.put;
 
 import com.google.gson.Gson;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
-import org.hl7.fhir.r5.formats.FormatUtilities;
 import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.OperationOutcome;
-import org.hl7.fhir.r5.model.Resource;
 import org.mitre.inferno.Validator;
 import spark.ResponseTransformer;
 
@@ -72,7 +68,7 @@ public class ValidatorEndpoint {
 
     post("/profiles",
         (req, res) -> {
-          loadProfile(req.bodyAsBytes());
+          validator.loadProfile(req.bodyAsBytes());
           return "";
         });
 
@@ -81,18 +77,6 @@ public class ValidatorEndpoint {
     get("/igs", (req, res) -> validator.getKnownIGs(), TO_JSON);
 
     put("/igs/:id", (req, res) -> validator.loadIg(req.params("id")), TO_JSON);
-  }
-
-  /**
-   * Handles loading FHIR profiles into the validator.
-   *
-   * @param profile the FHIR profile to be loaded
-   * @throws IOException if the profile could not be loaded
-   */
-  private void loadProfile(byte[] profile) throws IOException {
-    FhirFormat fmt = FormatUtilities.determineFormat(profile);
-    Resource resource = FormatUtilities.makeParser(fmt).parse(profile);
-    validator.loadProfile(resource);
   }
 
   /**

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -11,9 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.r5.elementmodel.Manager;
-import org.hl7.fhir.r5.formats.FormatUtilities;
-import org.hl7.fhir.r5.model.Resource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -49,12 +46,10 @@ public class ValidatorTest {
           .getClassLoader()
           .getResource("profile_fixture.json");
       byte[] profile = IOUtils.toByteArray(fixture);
-      Manager.FhirFormat fmt = FormatUtilities.determineFormat(profile);
-      Resource resource = FormatUtilities.makeParser(fmt).parse(profile);
       String profileUrl = "http://hl7.org/fhir/StructureDefinition/blah";
       boolean condition = isProfileLoaded(profileUrl);
       assertFalse(condition);
-      validator.loadProfile(resource);
+      validator.loadProfile(profile);
       condition = isProfileLoaded(profileUrl);
       assertTrue(condition);
     } catch (IOException e) {


### PR DESCRIPTION
This PR aims to reduce code duplication by leveraging features, such as `ResponseTransformer` that Spark offers. It also standardizes responses from the server e.g. making sure resource names are sorted and unique.