### PR TITLE
Revert "Update validation engine"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
     // the ig-publisher uses this one too
     // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.0.11-SNAPSHOT")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "4.3.1-SNAPSHOT")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -13,14 +13,14 @@ import org.hl7.fhir.r5.model.FhirPublication;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StructureDefinition;
-import org.hl7.fhir.validation.ValidationEngine;
+import org.hl7.fhir.r5.validation.ValidationEngine;
 import org.hl7.fhir.utilities.VersionUtilities;
-import org.hl7.fhir.utilities.cache.FilesystemPackageCacheManager;
+import org.hl7.fhir.utilities.cache.PackageCacheManager;
 import org.hl7.fhir.utilities.cache.ToolsVersion;
 
 public class Validator {
   ValidationEngine hl7Validator;
-  FilesystemPackageCacheManager packageManager;
+  PackageCacheManager packageManager;
 
   /**
    * The Validator is capable of validating FHIR Resources against FHIR Profiles.
@@ -42,10 +42,10 @@ public class Validator {
    *
    * @return
    */
-  private FilesystemPackageCacheManager getPackageManager() {
+  private PackageCacheManager getPackageManager() {
     if (packageManager == null) {
       try {
-        packageManager = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
+        packageManager = new PackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
       } catch (IOException e) {
         e.printStackTrace();
       }
@@ -103,7 +103,12 @@ public class Validator {
    * @return the list of IGs.
    */
   public List<String> getKnownIGs() {
-    return getPackageManager().listPackages();
+    try {
+      return getPackageManager().getUrls();
+    } catch (IOException e) {
+      e.printStackTrace();
+      return Arrays.asList("Failed to retrieve Implementation Guides");
+    }
   }
 
   /**

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -93,7 +93,8 @@ public class ValidatorTest {
   @Test
   void getKnownIGs() {
     List<String> knownIGs = validator.getKnownIGs();
-    assertTrue(knownIGs.contains("hl7.fhir.r4.core#4.0.1"));
+    assertTrue(knownIGs.contains("http://hl7.org/fhir/us/core"));
+    assertTrue(knownIGs.size() > 10);
   }
 
   boolean isProfileLoaded(String profile) {


### PR DESCRIPTION
Reverts inferno-community/fhir-validator-wrapper#10.

This is to support temporary separate versioning between inferno-program and inferno-community