### PR TITLE
FI-931: Add FHIRPath /evaluate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ to other applications that integrate it.
 
 ## REST API
 
-The FHIR Validation Service exposes two base paths: `/validator`, which prefixes all routes that talk to the HL7 Validator, and
-`/fhirpath`, which prefixes routes that evaluate FHIRPath expressions. **[See here](rest-api.md) for the REST API documentation.**
+**[See here](rest-api.md) for the REST API documentation.**
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ to other applications that integrate it.
 
 ## REST API
 
-**[See here](rest-api.md) for the REST API documentation.**
+The FHIR Validation Service exposes two base paths: `/validator`, which prefixes all routes that talk to the HL7 Validator, and
+`/fhirpath`, which prefixes routes that evaluate FHIRPath expressions. **[See here](rest-api.md) for the REST API documentation.**
 
 ## Installation
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -192,10 +192,6 @@
             <property name="lineWrappingIndentation" value="4"/>
             <property name="arrayInitIndent" value="2"/>
         </module>
-        <module name="AbbreviationAsWordInName">
-            <property name="ignoreFinal" value="false"/>
-            <property name="allowedAbbreviationLength" value="1"/>
-        </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.1.0

--- a/rest-api.md
+++ b/rest-api.md
@@ -73,7 +73,7 @@ the JSON or XML FHIR resource to serve as the root resource when evaluating the 
 - **Response:**
 a JSON array representing the result of evaluating the given expression against the given root resource.
 Each "result" in the returned array will be in the form
-`{ "type": "[FHIR datatype name]", "value": [JSON representation of result] }`.
+`{ "type": "[FHIR datatype name]", "element": [JSON representation of element] }`.
 
 # Example Requests and Responses
 

--- a/rest-api.md
+++ b/rest-api.md
@@ -2,7 +2,7 @@
 
 ### Validate a resource
 - **Route:**
-`POST /validator/validate`
+`POST /validate`
 - **Query Params:**
 `profile=[comma separated list of profile URLs]` (Required)
 - **Body:**
@@ -12,19 +12,19 @@ a JSON [OperationOutcome](https://www.hl7.org/fhir/operationoutcome.html)
 
 ### List supported resources
 - **Route:**
-`GET /validator/resources`
+`GET /resources`
 - **Response:**
 a JSON array of FHIR resource types known to the validator
 
 ### List supported profiles
 - **Route:**
-`GET /validator/profiles`
+`GET /profiles`
 - **Response:**
 a JSON array of [profile URLs](http://www.hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.url) known to the validator
 
 ### Load a custom profile
 - **Route:**
-`POST /validator/profiles`
+`POST /profiles`
 - **Body:**
 the JSON or XML [profile](http://www.hl7.org/fhir/structuredefinition.html) you want to load into the validator
 - **Response:**
@@ -32,19 +32,19 @@ None
 
 ### List profiles by implementation guide (IG)
 - **Route:**
-`GET /validator/profiles-by-ig`
+`GET /profiles-by-ig`
 - **Response:**
 a JSON object containing an array of profile URLs for each IG loaded into the validator
 
 ### List known IGs
 - **Route:**
-`GET /validator/igs`
+`GET /igs`
 - **Response:**
 a JSON object containing the canonical URL for each IG loaded into the validator
 
 ### Load an IG by NPM package ID
 - **Route:**
-`PUT /validator/igs/[NPM package ID]`
+`PUT /igs/[NPM package ID]`
 - **Query Params:**
 `version=[NPM package version]` (Optional)
 - **Response:**
@@ -52,7 +52,7 @@ the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#load
 
 ### Load a custom IG
 - **Route:**
-`POST /validator/igs`
+`POST /igs`
 - **Body:**
 the raw contents of the `package.tgz` tarball containing the IG to be loaded into the validator.  
 **The `package.tgz` contents must conform to the [NPM Package Specification](https://confluence.hl7.org/display/FHIR/NPM+Package+Specification)
@@ -65,7 +65,7 @@ the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#load
 
 ### Evaluate a FHIRPath expression
 - **Route:**
-`POST /fhirpath/evaluate`
+`POST /evaluate`
 - **Query Params:**
 `path=[FHIRPath expression]` (Required)
 - **Body:**
@@ -81,7 +81,7 @@ Each "result" in the returned array will be in the form
 This request assumes that the service is listening on port 4567.
 
 - **Example Request:**
-`curl -s -X PUT 'http://localhost:4567/validator/igs/hl7.fhir.us.qicore?version=4.9.0'`
+`curl -s -X PUT 'http://localhost:4567/igs/hl7.fhir.us.qicore?version=4.9.0'`
 - **Example Response:**
 ```
 {
@@ -100,7 +100,7 @@ This request assumes that the service is listening on port 4567 and that the `pa
 in the current working directory.
 
 - **Example Request:**
-`curl -s -X POST -H 'Content-Encoding: gzip' --data-binary '@package.tgz' 'http://localhost:4567/validator/igs'`
+`curl -s -X POST -H 'Content-Encoding: gzip' --data-binary '@package.tgz' 'http://localhost:4567/igs'`
 - **Example Response:**
 ```
 {

--- a/rest-api.md
+++ b/rest-api.md
@@ -2,7 +2,7 @@
 
 ### Validate a resource
 - **Route:**
-`POST /validate`
+`POST /validator/validate`
 - **Query Params:**
 `profile=[comma separated list of profile URLs]` (Required)
 - **Body:**
@@ -12,19 +12,19 @@ a JSON [OperationOutcome](https://www.hl7.org/fhir/operationoutcome.html)
 
 ### List supported resources
 - **Route:**
-`GET /resources`
+`GET /validator/resources`
 - **Response:**
 a JSON array of FHIR resource types known to the validator
 
 ### List supported profiles
 - **Route:**
-`GET /profiles`
+`GET /validator/profiles`
 - **Response:**
 a JSON array of [profile URLs](http://www.hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.url) known to the validator
 
 ### Load a custom profile
 - **Route:**
-`POST /profiles`
+`POST /validator/profiles`
 - **Body:**
 the JSON or XML [profile](http://www.hl7.org/fhir/structuredefinition.html) you want to load into the validator
 - **Response:**
@@ -32,19 +32,19 @@ None
 
 ### List profiles by implementation guide (IG)
 - **Route:**
-`GET /profiles-by-ig`
+`GET /validator/profiles-by-ig`
 - **Response:**
 a JSON object containing an array of profile URLs for each IG loaded into the validator
 
 ### List known IGs
 - **Route:**
-`GET /igs`
+`GET /validator/igs`
 - **Response:**
 a JSON object containing the canonical URL for each IG loaded into the validator
 
 ### Load an IG by NPM package ID
 - **Route:**
-`PUT /igs/[NPM package ID]`
+`PUT /validator/igs/[NPM package ID]`
 - **Query Params:**
 `version=[NPM package version]` (Optional)
 - **Response:**
@@ -52,7 +52,7 @@ the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#load
 
 ### Load a custom IG
 - **Route:**
-`POST /igs`
+`POST /validator/igs`
 - **Body:**
 the raw contents of the `package.tgz` tarball containing the IG to be loaded into the validator.  
 **The `package.tgz` contents must conform to the [NPM Package Specification](https://confluence.hl7.org/display/FHIR/NPM+Package+Specification)
@@ -61,13 +61,25 @@ Also note that the request must have the `Content-Encoding: gzip` header.
 - **Response:**
 the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#loading-a-custom-ig) for an example.
 
+# FHIRPath Routes
+
+### Evaluate a FHIRPath expression
+- **Route:**
+`POST /fhirpath/evaluate`
+- **Query Params:**
+`path=[FHIRPath expression]` (Required)
+- **Body:**
+the JSON or XML FHIR resource to serve as the root resource when evaluating the expression
+- **Response:**
+a JSON array representing the result of evaluating the given expression against the given root resource
+
 # Example Requests and Responses
 
 ### Loading an IG by ID and version
 This request assumes that the service is listening on port 4567.
 
 - **Example Request:**
-`curl -s -X PUT 'http://localhost:4567/igs/hl7.fhir.us.qicore?version=4.9.0'`
+`curl -s -X PUT 'http://localhost:4567/validator/igs/hl7.fhir.us.qicore?version=4.9.0'`
 - **Example Response:**
 ```
 {
@@ -86,7 +98,7 @@ This request assumes that the service is listening on port 4567 and that the `pa
 in the current working directory.
 
 - **Example Request:**
-`curl -s -X POST -H 'Content-Encoding: gzip' --data-binary '@package.tgz' 'http://localhost:4567/igs'`
+`curl -s -X POST -H 'Content-Encoding: gzip' --data-binary '@package.tgz' 'http://localhost:4567/validator/igs'`
 - **Example Response:**
 ```
 {

--- a/rest-api.md
+++ b/rest-api.md
@@ -69,9 +69,10 @@ the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#load
 - **Query Params:**
 `path=[FHIRPath expression]` (Required)
 - **Body:**
-the JSON or XML FHIR resource to serve as the root resource when evaluating the expression
+the JSON or XML FHIR element to serve as the root element when evaluating the expression. Accepts all
+complex datatypes (i.e. full resources, Elements, BackboneElements) but not primitives.
 - **Response:**
-a JSON array representing the result of evaluating the given expression against the given root resource.
+a JSON array representing the result of evaluating the given expression against the given root element.
 Each "result" in the returned array will be in the form
 `{ "type": "[FHIR datatype name]", "element": [JSON representation of element] }`.
 

--- a/rest-api.md
+++ b/rest-api.md
@@ -71,7 +71,9 @@ the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#load
 - **Body:**
 the JSON or XML FHIR resource to serve as the root resource when evaluating the expression
 - **Response:**
-a JSON array representing the result of evaluating the given expression against the given root resource
+a JSON array representing the result of evaluating the given expression against the given root resource.
+Each "result" in the returned array will be in the form
+`{ "type": "[FHIR datatype name]", "value": [JSON representation of result] }`.
 
 # Example Requests and Responses
 

--- a/src/main/java/org/mitre/inferno/App.java
+++ b/src/main/java/org/mitre/inferno/App.java
@@ -1,8 +1,6 @@
 package org.mitre.inferno;
 
 import java.io.IOException;
-import org.hl7.fhir.r5.context.SimpleWorkerContext;
-import org.hl7.fhir.r5.utils.FHIRPathEngine;
 import org.mitre.inferno.rest.Endpoints;
 import org.mitre.inferno.utils.SparkUtils;
 import org.slf4j.Logger;
@@ -44,12 +42,12 @@ public class App {
     }
   }
 
-  private static FHIRPathEngine initializePathEngine() {
+  private static FHIRPathEvaluator initializePathEvaluator() {
     Logger logger = LoggerFactory.getLogger(App.class);
     try {
-      return new FHIRPathEngine(new SimpleWorkerContext());
+      return new FHIRPathEvaluator();
     } catch (IOException e) {
-      logger.error("There was an error initializing the FHIRPath engine:", e);
+      logger.error("There was an error initializing the FHIRPath evaluator:", e);
       System.exit(1);
       return null; // unreachable
     }
@@ -64,7 +62,7 @@ public class App {
     SparkUtils.createServerWithRequestLog(logger);
     Endpoints.getInstance(
         initializeValidator(),
-        initializePathEngine(),
+        initializePathEvaluator(),
         getPortNumber()
     );
   }

--- a/src/main/java/org/mitre/inferno/App.java
+++ b/src/main/java/org/mitre/inferno/App.java
@@ -1,6 +1,9 @@
 package org.mitre.inferno;
 
-import org.mitre.inferno.rest.ValidatorEndpoint;
+import java.io.IOException;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.utils.FHIRPathEngine;
+import org.mitre.inferno.rest.Endpoints;
 import org.mitre.inferno.utils.SparkUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +44,17 @@ public class App {
     }
   }
 
+  private static FHIRPathEngine initializePathEngine() {
+    Logger logger = LoggerFactory.getLogger(App.class);
+    try {
+      return new FHIRPathEngine(new SimpleWorkerContext());
+    } catch (IOException e) {
+      logger.error("There was an error initializing the FHIRPath engine:", e);
+      System.exit(1);
+      return null; // unreachable
+    }
+  }
+
   /**
    * Starts the app.
    */
@@ -48,7 +62,11 @@ public class App {
     Logger logger = LoggerFactory.getLogger(App.class);
     logger.info("Starting Server...");
     SparkUtils.createServerWithRequestLog(logger);
-    ValidatorEndpoint.getInstance(initializeValidator(), getPortNumber());
+    Endpoints.getInstance(
+        initializeValidator(),
+        initializePathEngine(),
+        getPortNumber()
+    );
   }
 
   private static int getPortNumber() {

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -19,14 +19,13 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
 
   @Override
   public String evaluateToString(Base base, String path) {
-    List<Base> result = super.evaluate(base, path);
+    List<Base> result = this.evaluate(base, path);
     return '['
-        + result.stream().map(this::convertToString).collect(Collectors.joining(","))
+        + result.stream().map(this::baseToString).collect(Collectors.joining(","))
         + ']';
   }
 
-  @Override
-  public String convertToString(Base item) {
+  String baseToString(Base item) {
     String type = item.fhirType();
     if (item.isPrimitive()) {
       String value = item.primitiveValue();

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -27,7 +27,7 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
   }
 
   private String baseToJson(Base item) {
-    return String.format("{\"type\":\"%s\",\"value\":%s}", item.fhirType(), baseToString(item));
+    return String.format("{\"type\":\"%s\",\"element\":%s}", item.fhirType(), baseToString(item));
   }
 
   String baseToString(Base item) {

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -1,0 +1,53 @@
+package org.mitre.inferno;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.formats.JsonParser;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.Resource;
+import org.hl7.fhir.r5.utils.FHIRPathEngine;
+
+public class FHIRPathEvaluator extends FHIRPathEngine {
+
+  public FHIRPathEvaluator() throws IOException {
+    super(new SimpleWorkerContext());
+  }
+
+  @Override
+  public String evaluateToString(Base base, String path) {
+    List<Base> result = super.evaluate(base, path);
+    return '['
+        + result.stream().map(this::convertToString).collect(Collectors.joining(","))
+        + ']';
+  }
+
+  @Override
+  public String convertToString(Base item) {
+    String type = item.fhirType();
+    if (item.isPrimitive()) {
+      String value = item.primitiveValue();
+      switch (type) {
+        case "boolean":
+        case "integer":
+        case "decimal":
+          return value;
+        default: // TODO: handle date, dateTime, etc. appropriately
+          return '"' + value.replace("\"", "\\\"") + '"';
+      }
+    }
+    try {
+      if (item.isResource()) {
+        return new JsonParser().composeString((Resource) item);
+      } else if (item instanceof DataType) {
+        return new JsonParser().composeString((DataType) item, type);
+      }
+    } catch (IOException e) {
+      throw new FHIRException(String.format("Failed to compose item of type [%s].", type), e);
+    }
+    throw new IllegalArgumentException(String.format("[%s] was not a Resource or DataType.", type));
+  }
+}

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -38,9 +38,28 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
         case "boolean":
         case "integer":
         case "decimal":
+        case "unsignedInt":
+        case "positiveInt":
+          // convert to JSON boolean/number
           return value;
-        default: // TODO: handle date, dateTime, etc. appropriately
+        case "string":
+        case "uri":
+        case "url":
+        case "canonical":
+        case "base64Binary":
+        case "instant":
+        case "date":
+        case "dateTime":
+        case "time":
+        case "code":
+        case "oid":
+        case "id":
+        case "markdown":
+        case "uuid":
+          // convert to JSON string
           return new Gson().toJson(value);
+        default:
+          throw new IllegalArgumentException("Unexpected primitive type '" + type + "'.");
       }
     }
     try {
@@ -50,8 +69,8 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
         return new JsonParser().composeString((DataType) item, type);
       }
     } catch (IOException e) {
-      throw new FHIRException(String.format("Failed to compose item of type [%s].", type), e);
+      throw new FHIRException("Failed to compose item of type '" + type + "'.", e);
     }
-    throw new IllegalArgumentException(String.format("[%s] was not a Resource or DataType.", type));
+    throw new IllegalArgumentException("Type '" + type + "' was not a Resource or DataType.");
   }
 }

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -1,16 +1,11 @@
 package org.mitre.inferno;
 
-import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r5.context.SimpleWorkerContext;
-import org.hl7.fhir.r5.formats.JsonParser;
-import org.hl7.fhir.r5.model.Base;
-import org.hl7.fhir.r5.model.DataType;
-import org.hl7.fhir.r5.model.Resource;
-import org.hl7.fhir.r5.utils.FHIRPathEngine;
+import org.hl7.fhir.r4.context.SimpleWorkerContext;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.utils.FHIRPathEngine;
 
 public class FHIRPathEvaluator extends FHIRPathEngine {
 
@@ -27,50 +22,7 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
   }
 
   private String baseToJson(Base item) {
-    return String.format("{\"type\":\"%s\",\"element\":%s}", item.fhirType(), baseToString(item));
-  }
-
-  String baseToString(Base item) {
-    String type = item.fhirType();
-    if (item.isPrimitive()) {
-      String value = item.primitiveValue();
-      switch (type) {
-        case "boolean":
-        case "integer":
-        case "decimal":
-        case "unsignedInt":
-        case "positiveInt":
-          // convert to JSON boolean/number
-          return value;
-        case "string":
-        case "uri":
-        case "url":
-        case "canonical":
-        case "base64Binary":
-        case "instant":
-        case "date":
-        case "dateTime":
-        case "time":
-        case "code":
-        case "oid":
-        case "id":
-        case "markdown":
-        case "uuid":
-          // convert to JSON string
-          return new Gson().toJson(value);
-        default:
-          throw new IllegalArgumentException("Unexpected primitive type '" + type + "'.");
-      }
-    }
-    try {
-      if (item.isResource()) {
-        return new JsonParser().composeString((Resource) item);
-      } else if (item instanceof DataType) {
-        return new JsonParser().composeString((DataType) item, type);
-      }
-    } catch (IOException e) {
-      throw new FHIRException("Failed to compose item of type '" + type + "'.", e);
-    }
-    throw new IllegalArgumentException("Type '" + type + "' was not a Resource or DataType.");
+    String repr = new JsonParser().composeString(item);
+    return String.format("{\"type\":\"%s\",\"element\":%s}", item.fhirType(), repr);
   }
 }

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -39,7 +39,10 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
         case "decimal":
           return value;
         default: // TODO: handle date, dateTime, etc. appropriately
-          return '"' + value.replace("\"", "\\\"") + '"';
+          return '"'
+              + value.replace("\\", "\\\\")
+                  .replace("\"", "\\\"")
+              + '"';
       }
     }
     try {

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -3,6 +3,7 @@ package org.mitre.inferno;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.context.SimpleWorkerContext;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.utils.FHIRPathEngine;
@@ -22,7 +23,11 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
   }
 
   private String baseToJson(Base item) {
-    String repr = new JsonParser().composeString(item);
-    return String.format("{\"type\":\"%s\",\"element\":%s}", item.fhirType(), repr);
+    try {
+      String repr = new JsonParser().composeBase(item);
+      return String.format("{\"type\":\"%s\",\"element\":%s}", item.fhirType(), repr);
+    } catch (IOException e) {
+      throw new FHIRException("Failed to convert base to JSON", e);
+    }
   }
 }

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -21,8 +21,12 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
   public String evaluateToString(Base base, String path) {
     List<Base> result = this.evaluate(base, path);
     return '['
-        + result.stream().map(this::baseToString).collect(Collectors.joining(","))
+        + result.stream().map(this::baseToJson).collect(Collectors.joining(","))
         + ']';
+  }
+
+  private String baseToJson(Base item) {
+    return String.format("{\"type\":\"%s\",\"value\":%s}", item.fhirType(), baseToString(item));
   }
 
   String baseToString(Base item) {

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -1,5 +1,6 @@
 package org.mitre.inferno;
 
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,10 +40,7 @@ public class FHIRPathEvaluator extends FHIRPathEngine {
         case "decimal":
           return value;
         default: // TODO: handle date, dateTime, etc. appropriately
-          return '"'
-              + value.replace("\\", "\\\\")
-                  .replace("\"", "\\\"")
-              + '"';
+          return new Gson().toJson(value);
       }
     }
     try {

--- a/src/main/java/org/mitre/inferno/JsonParser.java
+++ b/src/main/java/org/mitre/inferno/JsonParser.java
@@ -11,7 +11,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.formats.JsonCreatorCanonical;
 import org.hl7.fhir.r4.formats.JsonCreatorDirect;
 import org.hl7.fhir.r4.model.BackboneElement;
@@ -36,22 +35,18 @@ public class JsonParser extends org.hl7.fhir.r4.formats.JsonParser {
     }
   }
 
-  public String composeString(Base item) {
+  public String composeBase(Base item) throws IOException {
     String type = item.fhirType();
-    try {
-      if (item.isPrimitive()) {
-        return composePrimitive(item);
-      } else if (item.isResource()) {
-        return composeString((Resource) item);
-      } else if (item instanceof Type) {
-        return composeString((Type) item, type);
-      } else if (item instanceof BackboneElement) {
-        return composeBackboneElement((BackboneElement) item);
-      } else {
-        throw new IllegalArgumentException("Unsupported type '" + type + "'.");
-      }
-    } catch (IOException e) {
-      throw new FHIRException("Failed to compose item of type '" + type + "'.", e);
+    if (item.isPrimitive()) {
+      return composePrimitive(item);
+    } else if (item.isResource()) {
+      return composeString((Resource) item);
+    } else if (item instanceof Type) {
+      return composeString((Type) item, type);
+    } else if (item instanceof BackboneElement) {
+      return composeBackboneElement((BackboneElement) item);
+    } else {
+      throw new IllegalArgumentException("Unsupported type '" + type + "'.");
     }
   }
 

--- a/src/main/java/org/mitre/inferno/JsonParser.java
+++ b/src/main/java/org/mitre/inferno/JsonParser.java
@@ -1,0 +1,112 @@
+package org.mitre.inferno;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.formats.JsonCreatorCanonical;
+import org.hl7.fhir.r4.formats.JsonCreatorDirect;
+import org.hl7.fhir.r4.model.BackboneElement;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Type;
+
+public class JsonParser extends org.hl7.fhir.r4.formats.JsonParser {
+
+  public Base parse(String input, String type) throws IOException {
+    JsonElement json = com.google.gson.JsonParser.parseString(input);
+    if (!json.isJsonObject()) {
+      throw new IllegalArgumentException("Expected JSON object.");
+    }
+    JsonObject obj = (JsonObject) json;
+    if (obj.has("resourceType")) {
+      return parse(obj);
+    } else {
+      return parseType(obj, type);
+    }
+  }
+
+  public String composeString(Base item) {
+    String type = item.fhirType();
+    if (item.isPrimitive()) {
+      String value = item.primitiveValue();
+      switch (type) {
+        case "boolean":
+        case "integer":
+        case "decimal":
+        case "unsignedInt":
+        case "positiveInt":
+          // convert to JSON boolean/number
+          return value;
+        case "string":
+        case "uri":
+        case "url":
+        case "canonical":
+        case "base64Binary":
+        case "instant":
+        case "date":
+        case "dateTime":
+        case "time":
+        case "code":
+        case "oid":
+        case "id":
+        case "markdown":
+        case "uuid":
+          // convert to JSON string
+          return new Gson().toJson(value);
+        default:
+          throw new IllegalArgumentException("Unexpected primitive type '" + type + "'.");
+      }
+    }
+    try {
+      if (item.isResource()) {
+        return composeString((Resource) item);
+      } else if (item instanceof Type) {
+        return composeString((Type) item, type);
+      } else if (item instanceof BackboneElement) {
+        return composeBackboneElement((BackboneElement) item);
+      } else {
+        throw new IllegalArgumentException("Type '" + type + "' was not a Resource or Type.");
+      }
+    } catch (IOException e) {
+      throw new FHIRException("Failed to compose item of type '" + type + "'.", e);
+    }
+  }
+
+  private String composeBackboneElement(BackboneElement element) throws IOException {
+    Class<?> clazz = element.getClass();
+    Class<?> enclosing = clazz.getEnclosingClass();
+    String methodName = "compose"
+        + (enclosing != null ? enclosing.getSimpleName() + clazz.getSimpleName() : "Backbone");
+    Method method;
+    try {
+      method = getClass().getSuperclass().getDeclaredMethod(methodName, String.class, clazz);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException("Could not find method '" + methodName + "'.", e);
+    }
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    OutputStreamWriter osw = new OutputStreamWriter(bytes, StandardCharsets.UTF_8);
+    if (style == OutputStyle.CANONICAL) {
+      json = new JsonCreatorCanonical(osw);
+    } else {
+      // use this instead of Gson because this preserves decimal formatting
+      json = new JsonCreatorDirect(osw);
+    }
+    json.setIndent(style == OutputStyle.PRETTY ? "  " : "");
+    try {
+      method.invoke(this, null, element);
+    } catch (Exception e) {
+      throw new RuntimeException("Error invoking method", e);
+    } finally {
+      json.finish();
+      osw.flush();
+    }
+    return bytes.toString();
+  }
+}

--- a/src/main/java/org/mitre/inferno/JsonParser.java
+++ b/src/main/java/org/mitre/inferno/JsonParser.java
@@ -20,6 +20,16 @@ import org.hl7.fhir.r4.model.Type;
 
 public class JsonParser extends org.hl7.fhir.r4.formats.JsonParser {
 
+  /**
+   * Parses the given string into an R4 FHIR model class. Supports all complex datatypes
+   * (Resources, Types, BackboneElements) but not primitives. The type parameter is required
+   * for parsing Types and BackboneElements, but is ignored for parsing Resources.
+   *
+   * @param input the input to parse
+   * @param type the FHIR type to parse the input into (e.g. "HumanName" or "Patient.contact")
+   * @return the FHIR model instance representing the parsed input
+   * @throws IOException if there was an error parsing the input
+   */
   public Base parse(String input, String type) throws IOException {
     JsonElement json = com.google.gson.JsonParser.parseString(input);
     if (!json.isJsonObject()) {
@@ -35,6 +45,13 @@ public class JsonParser extends org.hl7.fhir.r4.formats.JsonParser {
     }
   }
 
+  /**
+   * Converts the given Base element into its string representation.
+   *
+   * @param item the element to serialize
+   * @return the string representation of the input element
+   * @throws IOException if there was an error serializing the input
+   */
   public String composeBase(Base item) throws IOException {
     String type = item.fhirType();
     if (item.isPrimitive()) {

--- a/src/main/java/org/mitre/inferno/JsonParser.java
+++ b/src/main/java/org/mitre/inferno/JsonParser.java
@@ -38,48 +38,52 @@ public class JsonParser extends org.hl7.fhir.r4.formats.JsonParser {
 
   public String composeString(Base item) {
     String type = item.fhirType();
-    if (item.isPrimitive()) {
-      String value = item.primitiveValue();
-      switch (type) {
-        case "boolean":
-        case "integer":
-        case "decimal":
-        case "unsignedInt":
-        case "positiveInt":
-          // convert to JSON boolean/number
-          return value;
-        case "string":
-        case "uri":
-        case "url":
-        case "canonical":
-        case "base64Binary":
-        case "instant":
-        case "date":
-        case "dateTime":
-        case "time":
-        case "code":
-        case "oid":
-        case "id":
-        case "markdown":
-        case "uuid":
-          // convert to JSON string
-          return new Gson().toJson(value);
-        default:
-          throw new IllegalArgumentException("Unexpected primitive type '" + type + "'.");
-      }
-    }
     try {
-      if (item.isResource()) {
+      if (item.isPrimitive()) {
+        return composePrimitive(item);
+      } else if (item.isResource()) {
         return composeString((Resource) item);
       } else if (item instanceof Type) {
         return composeString((Type) item, type);
       } else if (item instanceof BackboneElement) {
         return composeBackboneElement((BackboneElement) item);
       } else {
-        throw new IllegalArgumentException("Type '" + type + "' was not a Resource or Type.");
+        throw new IllegalArgumentException("Unsupported type '" + type + "'.");
       }
     } catch (IOException e) {
       throw new FHIRException("Failed to compose item of type '" + type + "'.", e);
+    }
+  }
+
+  private String composePrimitive(Base primitive) {
+    String type = primitive.fhirType();
+    String value = primitive.primitiveValue();
+    switch (type) {
+      case "boolean":
+      case "integer":
+      case "decimal":
+      case "unsignedInt":
+      case "positiveInt":
+        // convert to JSON boolean/number
+        return value;
+      case "string":
+      case "uri":
+      case "url":
+      case "canonical":
+      case "base64Binary":
+      case "instant":
+      case "date":
+      case "dateTime":
+      case "time":
+      case "code":
+      case "oid":
+      case "id":
+      case "markdown":
+      case "uuid":
+        // convert to JSON string
+        return new Gson().toJson(value);
+      default:
+        throw new IllegalArgumentException("Unexpected primitive type '" + type + "'.");
     }
   }
 

--- a/src/main/java/org/mitre/inferno/Version.java
+++ b/src/main/java/org/mitre/inferno/Version.java
@@ -1,24 +1,23 @@
 package org.mitre.inferno;
 
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.Properties;
+import org.slf4j.LoggerFactory;
 
 public class Version {
   private static final String version;
 
   static {
-    String temp_version;
+    String tempVersion;
     try {
       Properties properties = new Properties();
       properties.load(Version.class.getClassLoader().getResourceAsStream("version.properties"));
-      temp_version = properties.getProperty("version");
+      tempVersion = properties.getProperty("version");
     } catch (IOException e) {
-      temp_version = null;
-      LoggerFactory.getLogger(Version.class).error("Failed to retrieve version: " +e.getMessage());
+      tempVersion = null;
+      LoggerFactory.getLogger(Version.class).error("Failed to retrieve version: " + e.getMessage());
     }
-    version = temp_version;
+    version = tempVersion;
   }
 
   public static String getVersion() {

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -1,0 +1,67 @@
+package org.mitre.inferno.rest;
+
+import static spark.Spark.before;
+import static spark.Spark.options;
+import static spark.Spark.path;
+import static spark.Spark.port;
+
+import com.google.gson.Gson;
+import org.hl7.fhir.r5.utils.FHIRPathEngine;
+import org.mitre.inferno.Validator;
+import spark.ResponseTransformer;
+
+public class Endpoints {
+  public static final ResponseTransformer TO_JSON = new Gson()::toJson;
+  private static Endpoints endpoints = null;
+
+  private final Validator validator;
+  private final FHIRPathEngine pathEngine;
+
+  private Endpoints(Validator validator, FHIRPathEngine engine, int portNum) {
+    this.validator = validator;
+    this.pathEngine = engine;
+    port(portNum);
+    createRoutes();
+  }
+
+  /**
+   * Get the existing Endpoints or create one if it does not already exist.
+   *
+   * @param validator the Validator that should be used at the /validator endpoint.
+   *                  Passing null will skip setting up the /validator endpoint.
+   * @param engine the FHIRPathEngine that should be used at the /fhirpath endpoint.
+   *               Passing null will skip setting up the /fhirpath endpoint.
+   * @return the singleton Endpoints
+   */
+  public static Endpoints getInstance(Validator validator, FHIRPathEngine engine, int portNum) {
+    if (endpoints == null) {
+      endpoints = new Endpoints(validator, engine, portNum);
+    }
+    return endpoints;
+  }
+
+  /**
+   * Creates the API routes for receiving and processing HTTP requests from clients.
+   */
+  private void createRoutes() {
+    // This adds permissive CORS headers to all requests
+    before((req, res) -> {
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
+      res.header("Access-Control-Allow-Headers", "Access-Control-Allow-Origin, Content-Type");
+    });
+
+    // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests,
+    // with a 200 OK response with no content and the CORS headers above
+    options("*", (req, res) -> "");
+
+    if (validator != null) {
+      path("/validator", () -> ValidatorEndpoint.getInstance(validator));
+    }
+
+    if (pathEngine != null) {
+      path("/fhirpath", () -> FHIRPathEndpoint.getInstance(pathEngine));
+    }
+  }
+
+}

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -6,7 +6,7 @@ import static spark.Spark.path;
 import static spark.Spark.port;
 
 import com.google.gson.Gson;
-import org.hl7.fhir.r5.utils.FHIRPathEngine;
+import org.mitre.inferno.FHIRPathEvaluator;
 import org.mitre.inferno.Validator;
 import spark.ResponseTransformer;
 
@@ -15,12 +15,12 @@ public class Endpoints {
   private static Endpoints endpoints = null;
 
   private final Validator validator;
-  private final FHIRPathEngine pathEngine;
+  private final FHIRPathEvaluator pathEvaluator;
 
-  private Endpoints(Validator validator, FHIRPathEngine engine, int portNum) {
+  private Endpoints(Validator validator, FHIRPathEvaluator evaluator, int port) {
     this.validator = validator;
-    this.pathEngine = engine;
-    port(portNum);
+    this.pathEvaluator = evaluator;
+    port(port);
     createRoutes();
   }
 
@@ -29,13 +29,14 @@ public class Endpoints {
    *
    * @param validator the Validator that should be used at the /validator endpoint.
    *                  Passing null will skip setting up the /validator endpoint.
-   * @param engine the FHIRPathEngine that should be used at the /fhirpath endpoint.
-   *               Passing null will skip setting up the /fhirpath endpoint.
+   * @param evaluator the FHIRPathEvaluator that should be used at the /fhirpath endpoint.
+   *                  Passing null will skip setting up the /fhirpath endpoint.
+   * @param port the port to list for requests on
    * @return the singleton Endpoints
    */
-  public static Endpoints getInstance(Validator validator, FHIRPathEngine engine, int portNum) {
+  public static Endpoints getInstance(Validator validator, FHIRPathEvaluator evaluator, int port) {
     if (endpoints == null) {
-      endpoints = new Endpoints(validator, engine, portNum);
+      endpoints = new Endpoints(validator, evaluator, port);
     }
     return endpoints;
   }
@@ -59,8 +60,8 @@ public class Endpoints {
       path("/validator", () -> ValidatorEndpoint.getInstance(validator));
     }
 
-    if (pathEngine != null) {
-      path("/fhirpath", () -> FHIRPathEndpoint.getInstance(pathEngine));
+    if (pathEvaluator != null) {
+      path("/fhirpath", () -> FHIRPathEndpoint.getInstance(pathEvaluator));
     }
   }
 

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -2,7 +2,6 @@ package org.mitre.inferno.rest;
 
 import static spark.Spark.before;
 import static spark.Spark.options;
-import static spark.Spark.path;
 import static spark.Spark.port;
 
 import com.google.gson.Gson;
@@ -57,11 +56,11 @@ public class Endpoints {
     options("*", (req, res) -> "");
 
     if (validator != null) {
-      path("/validator", () -> ValidatorEndpoint.getInstance(validator));
+      ValidatorEndpoint.getInstance(validator);
     }
 
     if (pathEvaluator != null) {
-      path("/fhirpath", () -> FHIRPathEndpoint.getInstance(pathEvaluator));
+      FHIRPathEndpoint.getInstance(pathEvaluator);
     }
   }
 

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -31,7 +31,7 @@ public class Endpoints {
    *                  Passing null will skip setting up the /validator endpoint.
    * @param evaluator the FHIRPathEvaluator that should be used at the /fhirpath endpoint.
    *                  Passing null will skip setting up the /fhirpath endpoint.
-   * @param port the port to list for requests on
+   * @param port the port to listen for requests on
    * @return the singleton Endpoints
    */
   public static Endpoints getInstance(Validator validator, FHIRPathEvaluator evaluator, int port) {

--- a/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
@@ -3,35 +3,29 @@ package org.mitre.inferno.rest;
 import static spark.Spark.post;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.formats.FormatUtilities;
-import org.hl7.fhir.r5.formats.JsonParser;
-import org.hl7.fhir.r5.model.Base;
-import org.hl7.fhir.r5.model.DataType;
 import org.hl7.fhir.r5.model.Resource;
-import org.hl7.fhir.r5.utils.FHIRPathEngine;
+import org.mitre.inferno.FHIRPathEvaluator;
 
 public class FHIRPathEndpoint {
   private static FHIRPathEndpoint fhirPathEndpoint = null;
-  private final FHIRPathEngine pathEngine;
+  private final FHIRPathEvaluator pathEvaluator;
 
-  private FHIRPathEndpoint(FHIRPathEngine engine) {
-    this.pathEngine = engine;
+  private FHIRPathEndpoint(FHIRPathEvaluator evaluator) {
+    this.pathEvaluator = evaluator;
     createRoutes();
   }
 
   /**
    * Get the existing FHIRPathEndpoint or create one if it does not already exist.
    *
-   * @param engine the FHIRPathEngine that should be used for this endpoint
+   * @param evaluator the FHIRPathEvaluator that should be used for this endpoint
    * @return the singleton FHIRPathEndpoint
    */
-  public static FHIRPathEndpoint getInstance(FHIRPathEngine engine) {
+  public static FHIRPathEndpoint getInstance(FHIRPathEvaluator evaluator) {
     if (fhirPathEndpoint == null) {
-      fhirPathEndpoint = new FHIRPathEndpoint(engine);
+      fhirPathEndpoint = new FHIRPathEndpoint(evaluator);
     }
     return fhirPathEndpoint;
   }
@@ -46,37 +40,9 @@ public class FHIRPathEndpoint {
     });
   }
 
-  private String convertToString(Base item) {
-    String type = item.fhirType();
-    if (item.isPrimitive()) {
-      String value = item.primitiveValue();
-      switch (type) {
-        case "boolean":
-        case "integer":
-        case "decimal":
-          return value;
-        default: // TODO: handle date, dateTime, etc. appropriately
-          return '"' + value.replace("\"", "\\\"") + '"';
-      }
-    }
-    try {
-      if (item.isResource()) {
-        return new JsonParser().composeString((Resource) item);
-      } else if (item instanceof DataType) {
-        return new JsonParser().composeString((DataType) item, type);
-      }
-    } catch (IOException e) {
-      throw new FHIRException(String.format("Failed to compose item of type [%s].", type), e);
-    }
-    throw new IllegalArgumentException(String.format("[%s] was not a Resource or DataType.", type));
-  }
-
   private String evaluate(byte[] body, String path) throws IOException {
     Manager.FhirFormat fmt = FormatUtilities.determineFormat(body);
     Resource rootResource = FormatUtilities.makeParser(fmt).parse(body);
-    List<Base> result = pathEngine.evaluate(rootResource, path);
-    return '['
-        + result.stream().map(this::convertToString).collect(Collectors.joining(","))
-        + ']';
+    return pathEvaluator.evaluateToString(rootResource, path);
   }
 }

--- a/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
@@ -3,10 +3,9 @@ package org.mitre.inferno.rest;
 import static spark.Spark.post;
 
 import java.io.IOException;
-import org.hl7.fhir.r5.elementmodel.Manager;
-import org.hl7.fhir.r5.formats.FormatUtilities;
-import org.hl7.fhir.r5.model.Resource;
+import org.hl7.fhir.r4.model.Base;
 import org.mitre.inferno.FHIRPathEvaluator;
+import org.mitre.inferno.JsonParser;
 
 public class FHIRPathEndpoint {
   private static FHIRPathEndpoint fhirPathEndpoint = null;
@@ -36,13 +35,12 @@ public class FHIRPathEndpoint {
   private void createRoutes() {
     post("/evaluate", (req, res) -> {
       res.type("application/fhir+json");
-      return evaluate(req.bodyAsBytes(), req.queryParams("path"));
+      return evaluate(req.body(), req.queryParams("type"), req.queryParams("path"));
     });
   }
 
-  private String evaluate(byte[] body, String path) throws IOException {
-    Manager.FhirFormat fmt = FormatUtilities.determineFormat(body);
-    Resource rootResource = FormatUtilities.makeParser(fmt).parse(body);
-    return pathEvaluator.evaluateToString(rootResource, path);
+  private String evaluate(String body, String type, String path) throws IOException {
+    Base rootElement = new JsonParser().parse(body, type);
+    return pathEvaluator.evaluateToString(rootElement, path);
   }
 }

--- a/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
@@ -1,5 +1,17 @@
 package org.mitre.inferno.rest;
 
+import static spark.Spark.post;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.formats.FormatUtilities;
+import org.hl7.fhir.r5.formats.JsonParser;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.utils.FHIRPathEngine;
 
 public class FHIRPathEndpoint {
@@ -28,5 +40,32 @@ public class FHIRPathEndpoint {
    * Creates the API routes for receiving and processing requests for the FHIRPath service.
    */
   private void createRoutes() {
+    post("/evaluate", (req, res) -> {
+      res.type("application/fhir+json");
+      return evaluate(req.bodyAsBytes(), req.queryParams("path"));
+    });
+  }
+
+  private String convertToString(Base item) {
+    String type = item.fhirType();
+    try {
+      if (item.isResource()) {
+        return new JsonParser().composeString((Resource) item);
+      } else if (item instanceof DataType) {
+        return new JsonParser().composeString((DataType) item, type);
+      }
+    } catch (IOException e) {
+      throw new FHIRException(String.format("Failed to compose item of type [%s].", type), e);
+    }
+    throw new IllegalArgumentException(String.format("[%s] was not a Resource or DataType.", type));
+  }
+
+  private String evaluate(byte[] body, String path) throws IOException {
+    Manager.FhirFormat fmt = FormatUtilities.determineFormat(body);
+    Resource rootResource = FormatUtilities.makeParser(fmt).parse(body);
+    List<Base> result = pathEngine.evaluate(rootResource, path);
+    return '['
+        + result.stream().map(this::convertToString).collect(Collectors.joining(","))
+        + ']';
   }
 }

--- a/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
@@ -48,6 +48,17 @@ public class FHIRPathEndpoint {
 
   private String convertToString(Base item) {
     String type = item.fhirType();
+    if (item.isPrimitive()) {
+      String value = item.primitiveValue();
+      switch (type) {
+        case "boolean":
+        case "integer":
+        case "decimal":
+          return value;
+        default: // TODO: handle date, dateTime, etc. appropriately
+          return '"' + value.replace("\"", "\\\"") + '"';
+      }
+    }
     try {
       if (item.isResource()) {
         return new JsonParser().composeString((Resource) item);

--- a/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/FHIRPathEndpoint.java
@@ -1,0 +1,32 @@
+package org.mitre.inferno.rest;
+
+import org.hl7.fhir.r5.utils.FHIRPathEngine;
+
+public class FHIRPathEndpoint {
+  private static FHIRPathEndpoint fhirPathEndpoint = null;
+  private final FHIRPathEngine pathEngine;
+
+  private FHIRPathEndpoint(FHIRPathEngine engine) {
+    this.pathEngine = engine;
+    createRoutes();
+  }
+
+  /**
+   * Get the existing FHIRPathEndpoint or create one if it does not already exist.
+   *
+   * @param engine the FHIRPathEngine that should be used for this endpoint
+   * @return the singleton FHIRPathEndpoint
+   */
+  public static FHIRPathEndpoint getInstance(FHIRPathEngine engine) {
+    if (fhirPathEndpoint == null) {
+      fhirPathEndpoint = new FHIRPathEndpoint(engine);
+    }
+    return fhirPathEndpoint;
+  }
+
+  /**
+   * Creates the API routes for receiving and processing requests for the FHIRPath service.
+   */
+  private void createRoutes() {
+  }
+}

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -1,29 +1,23 @@
 package org.mitre.inferno.rest;
 
-import static spark.Spark.before;
+import static org.mitre.inferno.rest.Endpoints.TO_JSON;
 import static spark.Spark.get;
-import static spark.Spark.options;
-import static spark.Spark.port;
 import static spark.Spark.post;
 import static spark.Spark.put;
 
-import com.google.gson.Gson;
 import java.util.Arrays;
 import java.util.List;
 import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.mitre.inferno.Validator;
 import org.mitre.inferno.Version;
-import spark.ResponseTransformer;
 
 public class ValidatorEndpoint {
   private static ValidatorEndpoint validatorEndpoint = null;
   private final Validator validator;
-  private static final ResponseTransformer TO_JSON = new Gson()::toJson;
 
-  private ValidatorEndpoint(Validator validator, int portNum) {
+  private ValidatorEndpoint(Validator validator) {
     this.validator = validator;
-    port(portNum);
     createRoutes();
   }
 
@@ -31,33 +25,19 @@ public class ValidatorEndpoint {
    * Get the existing ValidatorEndpoint or create one if it does not already exist.
    *
    * @param validator the Validator that should be used for this endpoint
-   * @param portNum the port that the ValidatorEndpoint should listen on
    * @return the singleton ValidatorEndpoint
    */
-  public static ValidatorEndpoint getInstance(Validator validator, int portNum) {
+  public static ValidatorEndpoint getInstance(Validator validator) {
     if (validatorEndpoint == null) {
-      validatorEndpoint = new ValidatorEndpoint(validator, portNum);
+      validatorEndpoint = new ValidatorEndpoint(validator);
     }
     return validatorEndpoint;
   }
 
   /**
-   * Creates the API routes for receiving and processing HTTP requests from clients.
+   * Creates the API routes for receiving and processing requests for the validation service.
    */
   private void createRoutes() {
-    // This adds permissive CORS headers to all requests
-    before((req, res) -> {
-      res.header("Access-Control-Allow-Origin", "*");
-      res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
-      res.header("Access-Control-Allow-Headers",
-          "Access-Control-Allow-Origin, Content-Type, Content-Encoding");
-      res.type("application/json");
-    });
-
-    // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests,
-    // with a 200 OK response with no content and the CORS headers above
-    options("*", (req, res) -> "");
-
     post("/validate",
         (req, res) -> {
           res.type("application/fhir+json");

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -1,0 +1,59 @@
+package org.mitre.inferno;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+import org.hl7.fhir.r5.formats.JsonParser;
+import org.hl7.fhir.r5.model.BooleanType;
+import org.hl7.fhir.r5.model.DecimalType;
+import org.hl7.fhir.r5.model.IntegerType;
+import org.hl7.fhir.r5.model.Resource;
+import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.UriType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class FHIRPathEvaluatorTest {
+  private static FHIRPathEvaluator pathEvaluator;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    pathEvaluator = new FHIRPathEvaluator();
+  }
+
+  @Test
+  void evaluateToString() throws IOException {
+    Resource patient = loadResource("patient_fixture.json");
+    assertEquals("[]", pathEvaluator.evaluateToString(patient, "Patient.foo"));
+    assertEquals("[\"234\"]", pathEvaluator.evaluateToString(patient, "Patient.id.substring(1,3)"));
+    assertEquals("[\"A\",\"B\",\"C\"]", pathEvaluator.evaluateToString(patient, "Patient.name.given"));
+    assertEquals(
+        "["
+            + "{\"given\":[\"A\"]},"
+            + "{\"given\":[\"B\"]},"
+            + "{\"given\":[\"C\"]}"
+            + "]",
+        pathEvaluator.evaluateToString(patient, "Patient.name")
+    );
+  }
+
+  @Test
+  void baseToString() {
+    // Unquoted primitives
+    assertEquals("false", pathEvaluator.baseToString(new BooleanType(false)));
+    assertEquals("10", pathEvaluator.baseToString(new IntegerType(10)));
+    assertEquals("3.51", pathEvaluator.baseToString(new DecimalType(3.51)));
+    // Quoted primitives
+    assertEquals("\"hello\"", pathEvaluator.baseToString(new StringType("hello")));
+    assertEquals("\"foo\"", pathEvaluator.baseToString(new UriType("foo")));
+  }
+
+  private Resource loadResource(String filename) throws IOException {
+    return new JsonParser().parse(loadFile(filename));
+  }
+
+  byte[] loadFile(String fileName) throws IOException {
+    return IOUtils.toByteArray(getClass().getClassLoader().getResource(fileName));
+  }
+}

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -26,16 +26,23 @@ class FHIRPathEvaluatorTest {
   void evaluateToString() throws IOException {
     Resource patient = loadResource("patient_fixture.json");
     assertEquals("[]", pathEvaluator.evaluateToString(patient, "Patient.foo"));
-    assertEquals("[\"234\"]", pathEvaluator.evaluateToString(patient, "Patient.id.substring(1,3)"));
     assertEquals(
-        "[\"A\",\"B\",\"C\"]",
+        "[{\"type\":\"string\",\"value\":\"234\"}]",
+        pathEvaluator.evaluateToString(patient, "Patient.id.substring(1,3)")
+    );
+    assertEquals(
+        "["
+            + "{\"type\":\"string\",\"value\":\"A\"},"
+            + "{\"type\":\"string\",\"value\":\"B\"},"
+            + "{\"type\":\"string\",\"value\":\"C\"}"
+            + "]",
         pathEvaluator.evaluateToString(patient, "Patient.name.given")
     );
     assertEquals(
         "["
-            + "{\"given\":[\"A\"]},"
-            + "{\"given\":[\"B\"]},"
-            + "{\"given\":[\"C\"]}"
+            + "{\"type\":\"HumanName\",\"value\":{\"given\":[\"A\"]}},"
+            + "{\"type\":\"HumanName\",\"value\":{\"given\":[\"B\"]}},"
+            + "{\"type\":\"HumanName\",\"value\":{\"given\":[\"C\"]}}"
             + "]",
         pathEvaluator.evaluateToString(patient, "Patient.name")
     );

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -27,7 +27,10 @@ class FHIRPathEvaluatorTest {
     Resource patient = loadResource("patient_fixture.json");
     assertEquals("[]", pathEvaluator.evaluateToString(patient, "Patient.foo"));
     assertEquals("[\"234\"]", pathEvaluator.evaluateToString(patient, "Patient.id.substring(1,3)"));
-    assertEquals("[\"A\",\"B\",\"C\"]", pathEvaluator.evaluateToString(patient, "Patient.name.given"));
+    assertEquals(
+        "[\"A\",\"B\",\"C\"]",
+        pathEvaluator.evaluateToString(patient, "Patient.name.given")
+    );
     assertEquals(
         "["
             + "{\"given\":[\"A\"]},"

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -4,13 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.r5.formats.JsonParser;
-import org.hl7.fhir.r5.model.BooleanType;
-import org.hl7.fhir.r5.model.DecimalType;
-import org.hl7.fhir.r5.model.IntegerType;
-import org.hl7.fhir.r5.model.Resource;
-import org.hl7.fhir.r5.model.StringType;
-import org.hl7.fhir.r5.model.UriType;
+import org.hl7.fhir.r4.formats.JsonParser;
+import org.hl7.fhir.r4.model.Resource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -46,17 +41,6 @@ class FHIRPathEvaluatorTest {
             + "]",
         pathEvaluator.evaluateToString(patient, "Patient.name")
     );
-  }
-
-  @Test
-  void baseToString() {
-    // Unquoted primitives
-    assertEquals("false", pathEvaluator.baseToString(new BooleanType(false)));
-    assertEquals("10", pathEvaluator.baseToString(new IntegerType(10)));
-    assertEquals("3.51", pathEvaluator.baseToString(new DecimalType(3.51)));
-    // Quoted primitives
-    assertEquals("\"hello\"", pathEvaluator.baseToString(new StringType("hello")));
-    assertEquals("\"foo\"", pathEvaluator.baseToString(new UriType("foo")));
   }
 
   private Resource loadResource(String filename) throws IOException {

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -41,6 +41,26 @@ class FHIRPathEvaluatorTest {
             + "]",
         pathEvaluator.evaluateToString(patient, "Patient.name")
     );
+    assertEquals(
+        "["
+          + "{"
+            + "\"type\":\"Patient.communication\","
+              + "\"element\":{"
+                + "\"language\":{"
+                  + "\"coding\":["
+                    + "{"
+                      + "\"system\":\"urn:ietf:bcp:47\","
+                      + "\"code\":\"en-US\","
+                      + "\"display\":\"English (United States)\""
+                    + "}"
+                  + "]"
+                + "},"
+              + "\"preferred\":true"
+            + "}"
+          + "}"
+        + "]",
+        pathEvaluator.evaluateToString(patient, "Patient.communication.where(preferred = true)")
+    );
   }
 
   private Resource loadResource(String filename) throws IOException {

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -27,22 +27,22 @@ class FHIRPathEvaluatorTest {
     Resource patient = loadResource("patient_fixture.json");
     assertEquals("[]", pathEvaluator.evaluateToString(patient, "Patient.foo"));
     assertEquals(
-        "[{\"type\":\"string\",\"value\":\"234\"}]",
+        "[{\"type\":\"string\",\"element\":\"234\"}]",
         pathEvaluator.evaluateToString(patient, "Patient.id.substring(1,3)")
     );
     assertEquals(
         "["
-            + "{\"type\":\"string\",\"value\":\"A\"},"
-            + "{\"type\":\"string\",\"value\":\"B\"},"
-            + "{\"type\":\"string\",\"value\":\"C\"}"
+            + "{\"type\":\"string\",\"element\":\"A\"},"
+            + "{\"type\":\"string\",\"element\":\"B\"},"
+            + "{\"type\":\"string\",\"element\":\"C\"}"
             + "]",
         pathEvaluator.evaluateToString(patient, "Patient.name.given")
     );
     assertEquals(
         "["
-            + "{\"type\":\"HumanName\",\"value\":{\"given\":[\"A\"]}},"
-            + "{\"type\":\"HumanName\",\"value\":{\"given\":[\"B\"]}},"
-            + "{\"type\":\"HumanName\",\"value\":{\"given\":[\"C\"]}}"
+            + "{\"type\":\"HumanName\",\"element\":{\"given\":[\"A\"]}},"
+            + "{\"type\":\"HumanName\",\"element\":{\"given\":[\"B\"]}},"
+            + "{\"type\":\"HumanName\",\"element\":{\"given\":[\"C\"]}}"
             + "]",
         pathEvaluator.evaluateToString(patient, "Patient.name")
     );

--- a/src/test/java/org/mitre/inferno/JsonParserTest.java
+++ b/src/test/java/org/mitre/inferno/JsonParserTest.java
@@ -1,0 +1,98 @@
+package org.mitre.inferno;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DecimalType;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.UriType;
+import org.junit.jupiter.api.Test;
+
+class JsonParserTest {
+  private static final JsonParser parser = new JsonParser();
+
+  @Test
+  void parse() throws IOException {
+    // Full resources
+    assertTrue(
+        new Patient().equalsDeep(parser.parse("{\"resourceType\":\"Patient\"}", null))
+    );
+
+    // Complex datatypes
+    assertTrue(
+        new HumanName().addGiven("Foo")
+            .equalsDeep(
+                parser.parse("{\"given\":[\"Foo\"]}", "HumanName")
+            )
+    );
+
+    // BackboneElements
+    assertTrue(
+        new Patient.PatientCommunicationComponent(
+            new CodeableConcept().addCoding(
+                new Coding()
+                    .setSystem("urn:ietf:bcp:47")
+                    .setCodeElement(new CodeType("en-US"))
+                    .setDisplay("English (United States)")
+            )
+        ).equalsDeep(
+            parser.parse(
+                "{"
+                    + "\"language\":"
+                    + "{\"coding\":["
+                    + "{\"system\":\"urn:ietf:bcp:47\","
+                    + "\"code\":\"en-US\","
+                    + "\"display\":\"English (United States)\""
+                    + "}]}}",
+                "Patient.communication"
+            )
+        )
+    );
+  }
+
+  @Test
+  void composeString() throws IOException {
+    // Unquoted primitives
+    assertEquals("false", parser.composeBase(new BooleanType(false)));
+    assertEquals("10", parser.composeBase(new IntegerType(10)));
+    assertEquals("3.51", parser.composeBase(new DecimalType(3.51)));
+    // Quoted primitives
+    assertEquals("\"hello\"", parser.composeBase(new StringType("hello")));
+    assertEquals("\"foo\"", parser.composeBase(new UriType("foo")));
+
+    // Full resources
+    assertEquals("{\"resourceType\":\"Patient\"}", parser.composeBase(new Patient()));
+
+    // Complex datatypes
+    assertEquals("{\"given\":[\"Foo\"]}", parser.composeBase(new HumanName().addGiven("Foo")));
+
+    // BackboneElements
+    assertEquals(
+        "{"
+            + "\"language\":"
+            + "{\"coding\":["
+            + "{\"system\":\"urn:ietf:bcp:47\","
+            + "\"code\":\"en-US\","
+            + "\"display\":\"English (United States)\""
+            + "}]}}",
+        parser.composeBase(
+            new Patient.PatientCommunicationComponent(
+                new CodeableConcept().addCoding(
+                    new Coding()
+                        .setSystem("urn:ietf:bcp:47")
+                        .setCodeElement(new CodeType("en-US"))
+                        .setDisplay("English (United States)")
+                )
+            )
+        )
+    );
+  }
+}

--- a/src/test/java/org/mitre/inferno/VersionTest.java
+++ b/src/test/java/org/mitre/inferno/VersionTest.java
@@ -1,8 +1,9 @@
 package org.mitre.inferno;
 
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 public class VersionTest {
 

--- a/src/test/resources/patient_fixture.json
+++ b/src/test/resources/patient_fixture.json
@@ -14,5 +14,30 @@
       "resourceType": "HumanName",
       "given": ["C"]
     }
+  ],
+  "communication": [
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "en-US",
+            "display": "English (United States)"
+          }
+        ]
+      },
+      "preferred": true
+    },
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "zh-CN",
+            "display": "Chinese (China)"
+          }
+        ]
+      }
+    }
   ]
 }

--- a/src/test/resources/patient_fixture.json
+++ b/src/test/resources/patient_fixture.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "Patient",
+  "id": "12345",
+  "name": [
+    {
+      "resourceType": "HumanName",
+      "given": ["A"]
+    },
+    {
+      "resourceType": "HumanName",
+      "given": ["B"]
+    },
+    {
+      "resourceType": "HumanName",
+      "given": ["C"]
+    }
+  ]
+}


### PR DESCRIPTION
[FI-931](https://oncprojectracking.healthit.gov/support/browse/FI-931): This PR <del>moves the validator routes into a subroute, `/validator/*`and</del> introduces another <del>sub</del>route `POST /evaluate?path=[FHIRPath]` for evaluating FHIRPaths against a resource (in the body of the request).