### PR TITLE
Fix handling of custom IGs

### DIFF
--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -114,7 +114,9 @@ public class Validator {
     Map<String, String> igs = new HashMap<>();
     // Add known custom IGs
     for (Map.Entry<String, NpmPackage> e : loadedPackages.entrySet()) {
-      igs.put(e.getKey(), e.getValue().canonical());
+      String id = e.getKey().split("#")[0];
+      String canonical = e.getValue().canonical();
+      igs.put(id, canonical);
     }
     // Add IGs known to the package manager, replacing any conflicting package IDs
     packageManager.listAllIds(igs);

--- a/src/main/java/org/mitre/inferno/rest/IgResponse.java
+++ b/src/main/java/org/mitre/inferno/rest/IgResponse.java
@@ -1,6 +1,17 @@
 package org.mitre.inferno.rest;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import org.hl7.fhir.utilities.TextFile;
+import org.hl7.fhir.utilities.cache.NpmPackage;
+import org.hl7.fhir.utilities.json.JSONUtil;
 
 public class IgResponse {
   public String id;
@@ -18,6 +29,31 @@ public class IgResponse {
     this.id = id;
     this.version = version;
     this.profiles = profiles;
+  }
+
+  /**
+   * Creates an IgResponse representing the given NpmPackage.
+   *
+   * @param npm the NpmPackage to represent as an IgResponse
+   * @return the IgResponse representing the given NpmPackage
+   * @throws IOException if the package's .index.json could not be read
+   */
+  public static IgResponse fromPackage(NpmPackage npm) throws IOException {
+    InputStream in = npm.load(".index.json");
+    JsonObject index = (JsonObject) JsonParser.parseString(TextFile.streamToString(in));
+
+    JsonArray files = index.getAsJsonArray("files");
+    List<String> profileUrls = new ArrayList<>();
+    for (JsonElement f : files) {
+      JsonObject file = (JsonObject) f;
+      String type = JSONUtil.str(file, "resourceType");
+      String url = JSONUtil.str(file, "url");
+      if (type.equals("StructureDefinition")) {
+        profileUrls.add(url);
+      }
+    }
+    Collections.sort(profileUrls);
+    return new IgResponse(npm.id(), npm.version(), profileUrls);
   }
 
   public String getId() {

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -48,7 +48,8 @@ public class ValidatorEndpoint {
     before((req, res) -> {
       res.header("Access-Control-Allow-Origin", "*");
       res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
-      res.header("Access-Control-Allow-Headers", "Access-Control-Allow-Origin, Content-Type, Content-Encoding");
+      res.header("Access-Control-Allow-Headers",
+          "Access-Control-Allow-Origin, Content-Type, Content-Encoding");
       res.type("application/json");
     });
 


### PR DESCRIPTION
This PR enables the functionality needed in the backend to support [FI-946: Add a way to load a package.tgz into the validator app](https://oncprojectracking.healthit.gov/support/browse/FI-946). Namely, it enables `PUT /igs/:custom-id` to return the profile URLs for a custom IG that has already been loaded into the validator. This PR also fixes a bug where custom IGs included the `#[version]` fragment in the map returned from `GET /igs` 