### PR TITLE
Adds OpenJDK14 Test to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+jdk:
+  - openjdk8
+  - openjdk14
+
 jobs:
   include:
     - name: "Build and Test"


### PR DESCRIPTION
Updates the `.travis.yml` so that tests are performed against JDK8 and JDK14 ([Travis docs here](https://docs.travis-ci.com/user/languages/java/#testing-against-multiple-jdks)).  The JDK8 tests are almost the same in both "Build and Test" and the JDK8 tests, but the "Build and Test" job also executes the `jar`, `startScripts`, `distTar`, `distZip`, and `assemble` tasks so I think its probably worth keeping.

This will hopefully help us keep the System Requirements listed in the README accurate and up to date.

_**Note: Travis is expected to fail for this PR until https://github.com/inferno-community/fhir-validator-wrapper/pull/23 is merged and this PR is rebased to incorporate those changes.**_