### PR TITLE
Bump validator version to 5.1.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
     // the ig-publisher uses this one too
     // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.1.4")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.1.7")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1
+version=1.0.2


### PR DESCRIPTION
This PR fixes the compilation errors that were happening because one of HAPI FHIR's moved.