### PR TITLE
Add OperationOutcome for validator issues that throw a Java Exception, and disable URL validation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.0
+version=1.2.0

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -119,7 +119,7 @@ public class Validator {
       OperationOutcomeIssueComponent issue = new OperationOutcomeIssueComponent(sev, IssueType.STRUCTURE);
       issue.setDiagnostics(e.getMessage());
       issue.setDetails(new CodeableConcept().setText(e.getMessage()));
-      issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line", new IntegerType(2));
+      issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line", new IntegerType(1));
       issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-col", new IntegerType(1));
       issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-source", new CodeType("ValidationService"));
       oo = new OperationOutcome(issue);

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -5,6 +5,7 @@ import static spark.Spark.get;
 import static spark.Spark.post;
 import static spark.Spark.put;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.hl7.fhir.r5.formats.JsonParser;
@@ -76,7 +77,13 @@ public class ValidatorEndpoint {
    * @throws Exception if the resource cannot be loaded or validated
    */
   private String validateResource(byte[] resource, String profile) throws Exception {
-    List<String> patientProfiles = Arrays.asList(profile.split(","));
+    List<String> patientProfiles;
+    if (profile != null) {
+      patientProfiles = Arrays.asList(profile.split(","));
+    } else {
+      patientProfiles = new ArrayList<String>();
+    }
+
     OperationOutcome oo = validator.validate(resource, patientProfiles);
     return new JsonParser().composeString(oo);
   }


### PR DESCRIPTION
This PR enables output of an `OperationOutcome` object when the HL7 `ValidationEngine` throws a Java `Exception` that would normally cause the server to return a `500` error. That way the FHIR Validator app/Inferno can more gracefully handle the error, rather than breaking.

Also, this PR disables validation of URL resolution. These errors were filtered out by Inferno anyways, but their presence could cause contained resources to unnecessarily fail validation, and throw other, more confusing errors, so this PR disables that validation permanently in the wrapper.