### PR TITLE
FI-1162: Update org.hl7.fhir.validator to version 5.3.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,13 @@ dependencies {
     // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
     // the ig-publisher uses this one too
     // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.2.10")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.3.6")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")
     implementation("org.apache.httpcomponents", "httpclient", "4.5.10")
     implementation("org.fhir", "ucum", "1.0.2")
+    implementation("com.squareup.okhttp3", "okhttp", "4.9.0")
 
     // GSON for our JSON needs
     implementation("com.google.code.gson", "gson", "2.8.6")

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -30,6 +30,7 @@ import org.hl7.fhir.utilities.npm.ToolsVersion;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.BaseValidator.ValidationControl;
+import org.hl7.fhir.validation.IgLoader;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.cli.utils.VersionUtil;
 import org.mitre.inferno.rest.IgResponse;
@@ -62,9 +63,10 @@ public class Validator {
                              .new ValidationControl(false, IssueSeverity.INFORMATION);
     hl7Validator.getValidationControl().put("Type_Specific_Checks_DT_URL_Resolve", vc);
 
-    hl7Validator.loadIg(igFile, true);
+    hl7Validator.getIgLoader().loadIg(hl7Validator.getIgs(), hl7Validator.getBinaries(), igFile, true);
+
     hl7Validator.connectToTSServer(txServer, txLog, FhirPublication.fromCode(fhirVersion));
-    hl7Validator.setNative(false);
+    hl7Validator.setDoNative(false);
     hl7Validator.setAnyExtensionsAllowed(true);
     hl7Validator.prepare();
 
@@ -193,7 +195,7 @@ public class Validator {
     NpmPackage npm = findCustomPackage(id, version);
     // Fallback to packages from packages.fhir.org if no custom packages match
     if (npm == null) {
-      hl7Validator.loadIg(id + (version != null ? "#" + version : ""), true);
+      hl7Validator.getIgLoader().loadIg(hl7Validator.getIgs(), hl7Validator.getBinaries(), id + (version != null ? "#" + version : ""), true);
       npm = packageManager.loadPackage(id, version);
     }
     return IgResponse.fromPackage(npm);
@@ -210,7 +212,7 @@ public class Validator {
     temp.deleteOnExit();
     try {
       FileUtils.writeByteArrayToFile(temp, content);
-      hl7Validator.loadIg(temp.getCanonicalPath(), true);
+      hl7Validator.getIgLoader().loadIg(hl7Validator.getIgs(), hl7Validator.getBinaries(), temp.getCanonicalPath(), true);
     } finally {
       temp.delete();
     }


### PR DESCRIPTION
This brings the underlying validation code up to version 5.3.6, the latest currently available. This brings it in line with HAPI 5.3, but requires updates to our IG loading code.