### PR TITLE
Allow all non-security headers through CORS

### DIFF
--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -48,7 +48,7 @@ public class Endpoints {
     before((req, res) -> {
       res.header("Access-Control-Allow-Origin", "*");
       res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
-      res.header("Access-Control-Allow-Headers", "Access-Control-Allow-Origin, Content-Type");
+      res.header("Access-Control-Allow-Headers", "*");
     });
 
     // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests,


### PR DESCRIPTION
Our old setup only allowed a subset of headers in a CORS request to the validator wrapper. There is no practical purpose to restricting headers, so this uses the wildcard `*` instead, to allow all non-security related headers. This means headers such as `Authorization` are still disallowed, but things like `Content-Encoding` and others are allowed.